### PR TITLE
fix(auth): stop auto-login page from wiping its own freshly-stored tokens

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -17,7 +17,10 @@ export const PROTECTED_PAGES = ["/account", "/wishlist", "/user"];
 // Legacy export — kept so callers that imported PUBLIC_PAGES still work.
 // Login / register surfaces are always reachable by definition; we list them
 // here so any leftover `PUBLIC_PAGES.includes(...)` check passes through.
-export const PUBLIC_PAGES = ["/login", "/register", "/forgot-password"];
+// `/auth/auto` is the bot auto-login interstitial — hide the header there so
+// it doesn't fire authenticated background requests (or drive logout) while
+// the one-time ticket is being exchanged.
+export const PUBLIC_PAGES = ["/login", "/register", "/forgot-password", "/auth/auto"];
 
 export const AUTH_TOKEN_STORAGE_KEY = "auth_token";
 

--- a/src/utils/authStorage.js
+++ b/src/utils/authStorage.js
@@ -2,6 +2,15 @@ import { removeItem } from "@/utils/storage";
 import { AUTH_TOKEN_STORAGE_KEY } from "@/config";
 
 export function clearAuthStorage() {
+  // Guard: the bot auto-login page (`/{locale}/auth/auto`) acquires a session
+  // from a one-time ticket. While it's doing that, the header/footer/LocaleSync
+  // each mount their own useAuth, see "no token yet", and fire logout →
+  // clearAuthStorage, which would wipe the tokens AutoLoginClient just stored
+  // (race → user lands unauthenticated). Never clear auth state on that page;
+  // let AutoLoginClient own the lifecycle. Normal pages clear as usual.
+  if (typeof window !== "undefined" && window.location.pathname.includes("/auth/auto")) {
+    return;
+  }
   removeItem(AUTH_TOKEN_STORAGE_KEY);
   removeItem("refresh_token");
   removeItem("token_expires_at");


### PR DESCRIPTION
Ticket 200 + token saqlanadi + hard reload — lekin user baribir unauthorized edi. Sabab: `/auth/auto`da Header/Footer/LocaleSync har biri `useAuth` mount qiladi, "token yo'q" deb `clearAuthStorage()` chaqiradi va AutoLoginClient endigina saqlagan tokenlarni o'chiradi (race). Fix: `clearAuthStorage` `/auth/auto`da no-op + sahifa PUBLIC_PAGES'ga (header yashirinadi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)