### PR TITLE
fix(auth): stand down useAuth on auto-login page (refresh-storm race)

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -21,6 +21,18 @@ export const useAuth = () => {
   const abortRef = useRef(null);
 
   const checkAuthStatus = useCallback(async () => {
+    // Stand down on the bot auto-login page. It acquires a session from a
+    // one-time ticket via AutoLoginClient; if the other useAuth consumers
+    // (footer, LocaleSync, cards…) also run here they fire concurrent
+    // refreshes — which rotate the refresh token (ROTATE_REFRESH_TOKENS), so
+    // the losers get 400 and clearAuthStorage() wipes the tokens the ticket
+    // exchange just stored, leaving the user logged out. Let AutoLoginClient
+    // own auth here; we re-check normally after its post-login hard reload.
+    if (typeof window !== "undefined" && window.location.pathname.includes("/auth/auto")) {
+      setIsLoading(false);
+      return;
+    }
+
     // Abort any in-flight check before starting a new one
     abortRef.current?.abort();
     const controller = new AbortController();


### PR DESCRIPTION
Birinchi auto-login urinishi unauthorized, ikkinchisi ishlardi. Sabab: POST /ticket-login (200) dan keyin bir nechta useAuth (footer/LocaleSync/cards) bir vaqtda /refresh chaqiradi → rotation → loser 400 → clearAuthStorage → token o'chadi. Fix: /auth/auto da useAuth.checkAuthStatus hech narsa qilmaydi; faqat AutoLoginClient ishlaydi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)