### PR TITLE
feat: gift/wish share buttons on book detail + analytics layer

### DIFF
--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -13,7 +13,8 @@ import {
   Skeleton,
   IconButton,
 } from "@mui/material";
-import { getBookById, logBookContact } from "@/services/books";
+import { getBookById, logBookContact, logBookShare } from "@/services/books";
+import { trackEvent } from "@/lib/analytics";
 import { useLike } from "@/hooks/useLike";
 import { useAuth } from "@/hooks/useAuth";
 import { openShareSheet } from "@/lib/shareSheet";
@@ -153,9 +154,33 @@ const BookDetails = ({ bookId }) => {
   const handleShare = () => {
     if (!book) return;
     const bookTitle = localizedField(book, "name", locale) || tBook("untitled");
+    trackEvent("book_share", { book_id: book.id });
     openShareSheet({
       title: bookTitle,
       text: `${bookTitle} — Kitobzor`,
+      url: typeof window !== "undefined" ? window.location.pathname : "",
+    });
+  };
+
+  // ── Gift loop ──────────────────────────────────────────────────────────
+  // A distribution feature: any visitor (no login needed) can forward this
+  // book to a friend either to receive it as a gift (`mode="wish"`) or to gift
+  // it to someone (`mode="gift"`). Both open the same share sheet pre-filled
+  // with a distinct message; the book link renders a rich Telegram/social
+  // preview from the per-book OG image. A fire-and-forget ping also tells the
+  // admin channel a warm gift-intent lead exists.
+  const handleGift = (mode) => {
+    if (!book) return;
+    const bookTitle = localizedField(book, "name", locale) || tBook("untitled");
+    const text =
+      mode === "gift"
+        ? tBook("giftGiveText", { name: bookTitle })
+        : tBook("giftWishText", { name: bookTitle });
+    logBookShare(book.id, mode);
+    trackEvent("book_gift_share", { book_id: book.id, mode });
+    openShareSheet({
+      title: bookTitle,
+      text,
       url: typeof window !== "undefined" ? window.location.pathname : "",
     });
   };
@@ -539,6 +564,73 @@ const BookDetails = ({ bookId }) => {
                 </IconButton>
               )}
             </Stack>
+
+            {/* Gift loop — forward this book to a friend to receive or give as
+                a gift. Open to everyone (no login gate): a public link with a
+                rich OG preview, plus a warm-lead ping to the admin channel. */}
+            <Box
+              sx={{
+                p: 1.75,
+                borderRadius: 2.5,
+                border: "1px dashed var(--border-subtle)",
+                bgcolor: "var(--surface-card)",
+              }}
+            >
+              <Typography
+                sx={{
+                  fontSize: 13,
+                  fontWeight: 700,
+                  mb: 1.25,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.75,
+                  color: "var(--text-primary)",
+                }}
+              >
+                <Icon className="ph-fill ph-gift" style={{ color: "#db2777", fontSize: 16 }} />
+                {tBook("giftTitle")}
+              </Typography>
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={1} useFlexGap>
+                <Button
+                  onClick={() => handleGift("wish")}
+                  variant="outlined"
+                  fullWidth
+                  startIcon={<Icon className="ph ph-sparkle" />}
+                  sx={{
+                    textTransform: "none",
+                    fontWeight: 700,
+                    justifyContent: "flex-start",
+                    color: "var(--text-primary)",
+                    borderColor: "var(--border-subtle)",
+                    "&:hover": {
+                      borderColor: "#db2777",
+                      bgcolor: "rgba(219, 39, 119, 0.06)",
+                    },
+                  }}
+                >
+                  {tBook("giftWish")}
+                </Button>
+                <Button
+                  onClick={() => handleGift("gift")}
+                  variant="outlined"
+                  fullWidth
+                  startIcon={<Icon className="ph ph-gift" />}
+                  sx={{
+                    textTransform: "none",
+                    fontWeight: 700,
+                    justifyContent: "flex-start",
+                    color: "var(--text-primary)",
+                    borderColor: "var(--border-subtle)",
+                    "&:hover": {
+                      borderColor: "#db2777",
+                      bgcolor: "rgba(219, 39, 119, 0.06)",
+                    },
+                  }}
+                >
+                  {tBook("giftGive")}
+                </Button>
+              </Stack>
+            </Box>
 
             {/* Seller card — one place, no duplicates. */}
             <Stack

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,0 +1,48 @@
+/**
+ * Thin, vendor-agnostic product-analytics layer.
+ *
+ * The goal is to instrument call sites *now* (search, contact, gift share,
+ * …) without committing to a vendor yet. `trackEvent` fans out to whatever
+ * is present on `window` at runtime — GA4/GTM (`dataLayer`/`gtag`) or
+ * PostHog (`posthog.capture`) — and is a safe no-op when none are wired.
+ * When Horizon 0 picks a vendor, only the provider script changes; these
+ * call sites stay put.
+ *
+ * Contract:
+ *   - SSR-safe: does nothing (and never throws) when `window` is undefined.
+ *   - Never throws: a broken/absent analytics SDK must never break a click.
+ *   - No PII: pass identifiers (ids, enums), not names/phones/emails.
+ */
+
+/**
+ * @param {string} name   - snake_case event name, e.g. "book_gift_share".
+ * @param {object} [props] - flat, non-PII properties (ids, enums, counts).
+ */
+export function trackEvent(name, props = {}) {
+  if (!name || typeof window === "undefined") return;
+
+  const payload = { ...props };
+
+  try {
+    // GA4 / Google Tag Manager.
+    if (Array.isArray(window.dataLayer)) {
+      window.dataLayer.push({ event: name, ...payload });
+    }
+    if (typeof window.gtag === "function") {
+      window.gtag("event", name, payload);
+    }
+    // PostHog.
+    if (window.posthog && typeof window.posthog.capture === "function") {
+      window.posthog.capture(name, payload);
+    }
+  } catch {
+    /* analytics must never break the UX — swallow transport errors */
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    // eslint-disable-next-line no-console -- dev-only, stripped in prod build
+    console.debug("📊 track", name, payload);
+  }
+}
+
+export default trackEvent;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -311,7 +311,12 @@
     "stats_likes": "{count, plural, one {# like} other {# likes}}",
     "stats_views": "{count, plural, one {# view} other {# views}}",
     "stats_comments": "{count, plural, one {# comment} other {# comments}}",
-    "untitled": "Book"
+    "untitled": "Book",
+    "giftTitle": "Gift it or ask for it",
+    "giftWish": "Ask someone to gift me",
+    "giftGive": "Gift it to someone",
+    "giftWishText": "📚 I'd love to read “{name}” — it would make me so happy if someone gifted it to me 🎁",
+    "giftGiveText": "📖 I'd like to gift you “{name}” — would you read it?"
   },
   "BookCard": {
     "noName": "Book Name Not Available",

--- a/src/messages/kaa.json
+++ b/src/messages/kaa.json
@@ -311,7 +311,12 @@
     "stats_likes": "{count, plural, one {# unatıw} other {# unatıw}}",
     "stats_views": "{count, plural, one {# kórilgen} other {# kórilgen}}",
     "stats_comments": "{count, plural, one {# pikir} other {# pikir}}",
-    "untitled": "Kitap"
+    "untitled": "Kitap",
+    "giftTitle": "Sıylıq etiw yamasa soraw",
+    "giftWish": "Maǵan sıylıq etsin",
+    "giftGive": "Jaqınıńızǵa sıylıq etiń",
+    "giftWishText": "📚 «{name}» kitabın oqıǵım keledi — kimde-kim maǵan sıylıq etse, júdá quwanar edim 🎁",
+    "giftGiveText": "📖 Saǵan «{name}» kitabın sıylıq etpekshimen, oqıysań ba?"
   },
   "BookCard": {
     "noName": "Kitap Atı Joq",

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -311,7 +311,12 @@
     "stats_likes": "{count, plural, one {# лайк} few {# лайка} many {# лайков} other {# лайков}}",
     "stats_views": "{count, plural, one {# просмотр} few {# просмотра} many {# просмотров} other {# просмотров}}",
     "stats_comments": "{count, plural, one {# комментарий} few {# комментария} many {# комментариев} other {# комментариев}}",
-    "untitled": "Книга"
+    "untitled": "Книга",
+    "giftTitle": "Подарить или попросить в подарок",
+    "giftWish": "Хочу получить в подарок",
+    "giftGive": "Подарить близкому",
+    "giftWishText": "📚 Хочу прочитать книгу «{name}» — будет здорово, если кто-нибудь подарит мне её 🎁",
+    "giftGiveText": "📖 Хочу подарить тебе книгу «{name}», прочитаешь?"
   },
   "BookCard": {
     "noName": "Название книги отсутствует",

--- a/src/messages/uz.json
+++ b/src/messages/uz.json
@@ -311,7 +311,12 @@
     "stats_likes": "{count, plural, one {# yoqtirish} other {# yoqtirish}}",
     "stats_views": "{count, plural, one {# ko'rilgan} other {# ko'rilgan}}",
     "stats_comments": "{count, plural, one {# izoh} other {# izoh}}",
-    "untitled": "Kitob"
+    "untitled": "Kitob",
+    "giftTitle": "Sovg'a qilish yoki so'rash",
+    "giftWish": "Menga sovg'a qilishsin",
+    "giftGive": "Yaqiningizga sovg'a qiling",
+    "giftWishText": "📚 «{name}» kitobini o'qimoqchiman — kimdir menga sovg'a qilsa juda xursand bo'lardim 🎁",
+    "giftGiveText": "📖 Senga «{name}» kitobini sovg'a qilmoqchiman, o'qiysanmi?"
   },
   "BookCard": {
     "noName": "Kitob Nomi Mavjud Emas",

--- a/src/services/books.js
+++ b/src/services/books.js
@@ -86,6 +86,22 @@ export async function logBookContact(id) {
   }
 }
 
+/**
+ * Notify the admin channel that a website visitor forwarded this book via the
+ * gift loop — either to gift it to someone (`kind="gift"`) or to receive it as
+ * a gift (`kind="wish"`). Fire-and-forget: a logging failure must never block
+ * the share sheet from opening. The backend tags the sharer (signed-in vs
+ * guest), threads the kind, and throttles repeats per visitor+book+kind.
+ */
+export async function logBookShare(id, kind) {
+  if (!id || !kind) return;
+  try {
+    await http.post(`${API_ENDPOINTS.BOOKS.DETAIL}/${id}/share/`, { kind });
+  } catch {
+    /* best-effort: never surface a notification failure to the user */
+  }
+}
+
 export async function getHomePageBooks() {
   return await getBooks({ for_home_page: true, is_active: true, limit: 12 });
 }

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { trackEvent } from "@/lib/analytics";
+
+describe("trackEvent", () => {
+  beforeEach(() => {
+    delete window.dataLayer;
+    delete window.gtag;
+    delete window.posthog;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("pushes to window.dataLayer when present (GA4/GTM)", () => {
+    window.dataLayer = [];
+    trackEvent("book_gift_share", { book_id: 42, mode: "gift" });
+    expect(window.dataLayer).toEqual([{ event: "book_gift_share", book_id: 42, mode: "gift" }]);
+  });
+
+  it("calls window.gtag when present", () => {
+    window.gtag = vi.fn();
+    trackEvent("book_share", { book_id: 7 });
+    expect(window.gtag).toHaveBeenCalledWith("event", "book_share", { book_id: 7 });
+  });
+
+  it("calls posthog.capture when present", () => {
+    window.posthog = { capture: vi.fn() };
+    trackEvent("search", { q: "aytmatov" });
+    expect(window.posthog.capture).toHaveBeenCalledWith("search", { q: "aytmatov" });
+  });
+
+  it("is a safe no-op when no provider is wired", () => {
+    expect(() => trackEvent("book_share", { book_id: 1 })).not.toThrow();
+  });
+
+  it("ignores an empty event name", () => {
+    window.dataLayer = [];
+    trackEvent("");
+    expect(window.dataLayer).toEqual([]);
+  });
+
+  it("never throws if a provider itself throws", () => {
+    window.gtag = () => {
+      throw new Error("sdk boom");
+    };
+    expect(() => trackEvent("book_share", { book_id: 1 })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Nima

Kitob detail sahifasiga **sovg'a loop** qo'shildi: ikkita tugma kitobni mavjud share-sheet orqali (Telegram birlamchi, OG muqova preview) tayyor matn bilan uzatadi:
- 🙏 **Menga sovg'a qilishsin** (`wish`) — "«{name}» kitobini o'qimoqchiman, kimdir sovg'a qilsa..."
- 🎁 **Yaqiningizga sovg'a qiling** (`gift`) — "Senga «{name}» kitobini sovg'a qilmoqchiman, o'qiysanmi?"

Hammaga ochiq (login gate yo'q) — ommaviy link hech qanday kontakt ma'lumotini oshkor qilmaydi; qabul qiluvchi kontaktga bosgandagina login-gate'ga uchraydi. Telegram linkdan kitob muqovasini OG orqali avtomatik preview qiladi.

## O'zgarishlar
- **`src/lib/analytics.js`** — ingichka, vendor-agnostik `trackEvent()` (dataLayer/gtag/posthog fan-out, SSR-safe, hech qachon throw qilmaydi). Call-site'lar hozir instrumented — Horizon 0 vendor tanlovi bir qatorlik provider almashtirishga aylanadi. + unit testlar.
- **`src/services/books.js`** — `logBookShare(id, kind)` fire-and-forget POST `/book/<id>/share/`.
- **`BookDetails.jsx`** — sovg'a bloki (wish/gift) + `handleGift`; umumiy share va sovg'a share'da `trackEvent`.
- **`messages/{uz,ru,en,kaa}.json`** — sovg'a kalitlari (i18n:check yashil, 808 kalit × 4 til).

## Backend bog'liqligi
`POST /api/v1/book/<id>/share/` — backend companion PR: menOtabek/kitobzor#94.

## Test / gate
- `npm run lint` ✅ (faqat mavjud img/sanitize warninglar)
- `npm test` ✅ 154/154 (yangi 6 analytics test)
- `npm run i18n:check` ✅ 808 kalit
- `npm run build` ✅ (`NEXT_PUBLIC_API_BASE_URL=https://api-dev.kitobzor.uz/`)

## Manual test plan (360/768/1440)
Ikkala tugma render bo'ladi; bosilganda share-sheet to'g'ri tayyor matn bilan ochiladi; ulashilgan link absolyut URL bilan ketadi → Telegram muqova preview'ini ko'rsatadi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)