### PR TITLE
feat(seo): hreflang + canonical across all public pages

### DIFF
--- a/src/app/[locale]/about-us/page.jsx
+++ b/src/app/[locale]/about-us/page.jsx
@@ -5,17 +5,22 @@ import Breadcrumb from "@/components/Breadcrumb";
 import AboutUs from "@/components/AboutUs";
 import ColorInit from "@/helper/ColorInit";
 import ScrollToTopInit from "@/helper/ScrollToTopInit";
+import { buildAlternates } from "@/lib/seo/alternates";
 
 const FooterOne = dynamic(() => import("@/components/FooterOne"));
 const BottomFooter = dynamic(() => import("@/components/BottomFooter"));
 
 export const revalidate = 86400;
 
-export const metadata = {
-  title: "Biz haqimizda - Kitobzor",
-  description:
-    "Kitobzor - kitob do'konlari va kitob sevuvchilarini birlashtiruvchi innovatsion platforma. Bizning missiyamiz va ko'rsatkichimiz haqida batafsil ma'lumot.",
-};
+export async function generateMetadata({ params }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "AboutUs" });
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    alternates: buildAlternates(locale, "about-us"),
+  };
+}
 
 const page = async () => {
   const tBreadcrumb = await getTranslations("Breadcrumb");

--- a/src/app/[locale]/community/[type]/page.jsx
+++ b/src/app/[locale]/community/[type]/page.jsx
@@ -5,6 +5,7 @@ import Breadcrumb from "@/components/Breadcrumb";
 import CommunityBooksPage from "@/components/CommunityBooksPage";
 import ColorInit from "@/helper/ColorInit";
 import ScrollToTopInit from "@/helper/ScrollToTopInit";
+import { buildAlternates } from "@/lib/seo/alternates";
 
 const FooterOne = dynamic(() => import("@/components/FooterOne"));
 const BottomFooter = dynamic(() => import("@/components/BottomFooter"));
@@ -18,6 +19,7 @@ export async function generateMetadata({ params }) {
   return {
     title: `${t(`title.${type}`)} — Kitobzor`,
     description: t(`subtitle.${type}`),
+    alternates: buildAlternates(locale, `community/${type}`),
   };
 }
 

--- a/src/app/[locale]/contact/layout.js
+++ b/src/app/[locale]/contact/layout.js
@@ -1,8 +1,5 @@
-export const metadata = {
-  title: "Bog'lanish - Kitobzor",
-  description: "Kitobzor bilan bog'lanish sahifasi",
-};
-
+// Metadata (incl. locale-aware title/description + hreflang alternates) is
+// defined on the page via generateMetadata — this layout is a passthrough.
 export default function ContactLayout({ children }) {
   return <>{children}</>;
 }

--- a/src/app/[locale]/contact/page.jsx
+++ b/src/app/[locale]/contact/page.jsx
@@ -4,6 +4,7 @@ import Breadcrumb from "@/components/Breadcrumb";
 import Contact from "@/components/Contact";
 import ColorInit from "@/helper/ColorInit";
 import ScrollToTopInit from "@/helper/ScrollToTopInit";
+import { buildAlternates } from "@/lib/seo/alternates";
 
 // FaqSection used to render below the contact form. It was pulled — FAQ
 // has a dedicated page reachable from the header menu and footer link,
@@ -14,11 +15,15 @@ const BottomFooter = dynamic(() => import("@/components/BottomFooter"));
 
 export const revalidate = 86400;
 
-export const metadata = {
-  title: "Aloqa — Kitobzor",
-  description:
-    "Kitobzor jamoasi bilan bog'lanish: savol, taklif yoki muammoingiz bo'lsa, biz bilan aloqaga chiqing.",
-};
+export async function generateMetadata({ params }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Contact" });
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    alternates: buildAlternates(locale, "contact"),
+  };
+}
 
 const page = async () => {
   const tBreadcrumb = await getTranslations("Breadcrumb");

--- a/src/app/[locale]/faq/page.jsx
+++ b/src/app/[locale]/faq/page.jsx
@@ -6,23 +6,13 @@ import ColorInit from "@/helper/ColorInit";
 import ScrollToTopInit from "@/helper/ScrollToTopInit";
 import JsonLd from "@/components/seo/JsonLd";
 import { serverGet, unwrapList } from "@/lib/serverFetch";
-import { getSiteUrl } from "@/config/env";
 import { faqPageLd, breadcrumbLd } from "@/lib/seo/jsonLd";
-import { routing } from "@/i18n/routing";
+import { buildAlternates } from "@/lib/seo/alternates";
 
 const FooterOne = dynamic(() => import("@/components/FooterOne"));
 const BottomFooter = dynamic(() => import("@/components/BottomFooter"));
 
 export const revalidate = 86400;
-
-const SITE_URL = getSiteUrl();
-
-function buildLanguageAlternates() {
-  const languages = {};
-  for (const loc of routing.locales) languages[loc] = `${SITE_URL}/${loc}/faq`;
-  languages["x-default"] = `${SITE_URL}/uz/faq`;
-  return languages;
-}
 
 export async function generateMetadata({ params }) {
   const { locale } = await params;
@@ -30,10 +20,7 @@ export async function generateMetadata({ params }) {
   return {
     title: t("title"),
     description: t("subtitle"),
-    alternates: {
-      canonical: `${SITE_URL}/${locale}/faq`,
-      languages: buildLanguageAlternates(),
-    },
+    alternates: buildAlternates(locale, "faq"),
   };
 }
 

--- a/src/app/[locale]/policies/page.jsx
+++ b/src/app/[locale]/policies/page.jsx
@@ -4,6 +4,7 @@ import Breadcrumb from "@/components/Breadcrumb";
 import PoliciesSection from "@/components/PoliciesSection";
 import ColorInit from "@/helper/ColorInit";
 import ScrollToTopInit from "@/helper/ScrollToTopInit";
+import { buildAlternates } from "@/lib/seo/alternates";
 
 const FooterOne = dynamic(() => import("@/components/FooterOne"));
 const BottomFooter = dynamic(() => import("@/components/BottomFooter"));
@@ -16,6 +17,7 @@ export async function generateMetadata({ params }) {
   return {
     title: `${t("title")} — Kitobzor`,
     description: t("subtitle"),
+    alternates: buildAlternates(locale, "policies"),
   };
 }
 

--- a/src/app/[locale]/shops/page.jsx
+++ b/src/app/[locale]/shops/page.jsx
@@ -4,6 +4,7 @@ import Breadcrumb from "@/components/Breadcrumb";
 import ShopsListPage from "@/components/ShopsListPage";
 import ColorInit from "@/helper/ColorInit";
 import ScrollToTopInit from "@/helper/ScrollToTopInit";
+import { buildAlternates } from "@/lib/seo/alternates";
 
 const FooterOne = dynamic(() => import("@/components/FooterOne"));
 const BottomFooter = dynamic(() => import("@/components/BottomFooter"));
@@ -16,6 +17,7 @@ export async function generateMetadata({ params }) {
   return {
     title: `${t("title")} — Kitobzor`,
     description: t("subtitle"),
+    alternates: buildAlternates(locale, "shops"),
   };
 }
 

--- a/src/lib/seo/alternates.js
+++ b/src/lib/seo/alternates.js
@@ -1,0 +1,36 @@
+/**
+ * Single source of truth for a page's `alternates` metadata (canonical +
+ * hreflang). Every locale-prefixed route differs only by its `/{locale}`
+ * segment, so callers pass the locale-agnostic `suffix` (the path *after*
+ * the locale) and get back the full `alternates` object Next.js expects.
+ *
+ *   buildAlternates("uz", "community/all")
+ *   → { canonical: "https://…/uz/community/all",
+ *       languages: { uz: "…/uz/community/all", ru: "…/ru/community/all",
+ *                    en: …, kaa: …, "x-default": "…/uz/community/all" } }
+ *
+ * hreflang tells Google these are the same page in different languages
+ * (no duplicate-content penalty); x-default points at the uz canonical.
+ * Replaces the per-page `buildLanguageAlternates` copies so the 4-locale
+ * list can never drift between pages.
+ */
+import { routing } from "@/i18n/routing";
+import { getSiteUrl } from "@/config/env";
+
+const SITE_URL = getSiteUrl();
+const DEFAULT_LOCALE = routing.defaultLocale || "uz";
+
+export function buildAlternates(locale, suffix = "") {
+  const clean = suffix ? `/${String(suffix).replace(/^\/+/, "")}` : "";
+  const languages = {};
+  for (const loc of routing.locales) {
+    languages[loc] = `${SITE_URL}/${loc}${clean}`;
+  }
+  languages["x-default"] = `${SITE_URL}/${DEFAULT_LOCALE}${clean}`;
+  return {
+    canonical: `${SITE_URL}/${locale}${clean}`,
+    languages,
+  };
+}
+
+export default buildAlternates;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -235,7 +235,9 @@
     "telegramChannel": "Telegram channel",
     "telegramCaption": "News and announcements",
     "instagram": "Instagram",
-    "instagramCaption": "Books and shops"
+    "instagramCaption": "Books and shops",
+    "metaTitle": "Contact us",
+    "metaDescription": "Get in touch with the Kitobzor team — questions, suggestions or issues, we're here to help."
   },
   "Auth": {
     "welcome": "Welcome to Kitobzor!",
@@ -693,7 +695,9 @@
       "title": "Join Our Community",
       "description": "Become a seller or explore our shops",
       "exploreShops": "Explore Shops"
-    }
+    },
+    "metaTitle": "About us",
+    "metaDescription": "Kitobzor — a platform connecting bookstores and book lovers. Our mission and what we stand for."
   },
   "ThemeToggle": {
     "switchToDark": "Switch to dark mode",

--- a/src/messages/kaa.json
+++ b/src/messages/kaa.json
@@ -235,7 +235,9 @@
     "telegramChannel": "Telegram kanal",
     "telegramCaption": "Jańalıqlar hám járiyalawlar",
     "instagram": "Instagram",
-    "instagramCaption": "Kitaplar hám dúkenler haqqında"
+    "instagramCaption": "Kitaplar hám dúkenler haqqında",
+    "metaTitle": "Baylanıs",
+    "metaDescription": "Kitobzor toparı menen baylanısıń: sorawıńız, usınısıńız yamasa máseleńiz bolsa, biz benen baylanısıń."
   },
   "Auth": {
     "welcome": "Kitobzorǵa xosh kelipsiz!",
@@ -693,7 +695,9 @@
       "title": "Bizdiń jámáátimizge qosılıń",
       "description": "Satıwshı bolıń yáki bizdiń dúkenlerimizdi kórip shıǵıń",
       "exploreShops": "Dúkenlerdi kóriw"
-    }
+    },
+    "metaTitle": "Biz haqqımızda",
+    "metaDescription": "Kitobzor — kitap dúkanları hám kitap súygenlerdi birlestiretuǵın platforma. Bizdiń maqsetimiz hám kórsetkishlerimiz."
   },
   "ThemeToggle": {
     "switchToDark": "Túngi rejimge ótiw",

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -235,7 +235,9 @@
     "telegramChannel": "Telegram-канал",
     "telegramCaption": "Новости и объявления",
     "instagram": "Instagram",
-    "instagramCaption": "Книги и магазины"
+    "instagramCaption": "Книги и магазины",
+    "metaTitle": "Связаться с нами",
+    "metaDescription": "Свяжитесь с командой Kitobzor: вопросы, предложения или проблемы — мы всегда на связи."
   },
   "Auth": {
     "welcome": "Добро пожаловать в Kitobzor!",
@@ -693,7 +695,9 @@
       "title": "Присоединяйтесь к нашему сообществу",
       "description": "Станьте продавцом или изучите наши магазины",
       "exploreShops": "Изучить магазины"
-    }
+    },
+    "metaTitle": "О нас",
+    "metaDescription": "Kitobzor — платформа, объединяющая книжные магазины и любителей книг. Наша миссия и показатели."
   },
   "ThemeToggle": {
     "switchToDark": "Перейти в тёмный режим",

--- a/src/messages/uz.json
+++ b/src/messages/uz.json
@@ -235,7 +235,9 @@
     "telegramChannel": "Telegram kanal",
     "telegramCaption": "Yangiliklar va e'lonlar",
     "instagram": "Instagram",
-    "instagramCaption": "Kitoblar va do'konlar haqida"
+    "instagramCaption": "Kitoblar va do'konlar haqida",
+    "metaTitle": "Bog'lanish",
+    "metaDescription": "Kitobzor jamoasi bilan bog'laning: savol, taklif yoki muammoingiz bo'lsa, biz bilan aloqaga chiqing."
   },
   "Auth": {
     "welcome": "Kitobzorga xush kelibsiz!",
@@ -693,7 +695,9 @@
       "title": "Bizning jamoamizga qo'shiling",
       "description": "Sotuvchi bo'ling yoki bizning do'konlarimizni ko'rib chiqing",
       "exploreShops": "Do'konlarni ko'rish"
-    }
+    },
+    "metaTitle": "Biz haqimizda",
+    "metaDescription": "Kitobzor — kitob do'konlari va kitobxonlarni birlashtiruvchi platforma. Bizning missiyamiz va ko'rsatkichlarimiz."
   },
   "ThemeToggle": {
     "switchToDark": "Tungi rejimga o'tish",

--- a/tests/unit/alternates.test.js
+++ b/tests/unit/alternates.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { buildAlternates } from "@/lib/seo/alternates";
+import { routing } from "@/i18n/routing";
+
+describe("buildAlternates", () => {
+  it("emits a canonical for the active locale + suffix", () => {
+    const { canonical } = buildAlternates("ru", "community/all");
+    expect(canonical).toMatch(/\/ru\/community\/all$/);
+  });
+
+  it("emits an hreflang entry for every locale plus x-default", () => {
+    const { languages } = buildAlternates("uz", "shops");
+    for (const loc of routing.locales) {
+      expect(languages[loc]).toMatch(new RegExp(`/${loc}/shops$`));
+    }
+    expect(languages["x-default"]).toMatch(/\/uz\/shops$/);
+  });
+
+  it("normalizes a leading slash in the suffix", () => {
+    const a = buildAlternates("en", "/faq");
+    const b = buildAlternates("en", "faq");
+    expect(a.canonical).toBe(b.canonical);
+    expect(a.canonical).toMatch(/\/en\/faq$/);
+  });
+
+  it("handles an empty suffix (home) with no trailing slash", () => {
+    const { canonical, languages } = buildAlternates("uz", "");
+    expect(canonical).toMatch(/\/uz$/);
+    expect(languages["x-default"]).toMatch(/\/uz$/);
+  });
+
+  it("uses absolute https URLs (so crawlers resolve the host)", () => {
+    const { canonical } = buildAlternates("uz", "policies");
+    expect(canonical).toMatch(/^https?:\/\//);
+  });
+});


### PR DESCRIPTION
## Nima

SEO auditdagi crawlability teshigini yopadi: **community, shops (ro'yxat), policies, about-us, contact** sahifalari `alternates` (canonical + hreflang) **umuman emit qilmasdi** → Google 4 til variantini bog'lanmagan/dublikat deb ko'rardi.

- **`src/lib/seo/alternates.js`** — yagona manba `buildAlternates(locale, suffix)` → `{ canonical, languages{uz,ru,en,kaa,x-default} }`. Per-page `buildLanguageAlternates` nusxalari o'rniga (drift bo'lmaydi).
- **canonical + hreflang qo'shildi:** `community/[type]`, `shops`, `policies`, `about-us`, `contact`. `faq` shared helper'ga ko'chirildi.
- **about-us & contact endi locale-aware** (`generateMetadata` + yangi `AboutUs`/`Contact` `metaTitle`+`metaDescription`, 4 til) — avvalgi hardcode o'zbekcha string o'rniga; `contact/layout.js`dagi ortiqcha static metadata olib tashlandi.
- `tests/unit/alternates.test.js` (5 test). i18n 812 kalit × 4 sinxron.

## Skoup
Ataylab faqat **metadata** (data-flow/routing riski nol). Client-render community/shops ro'yxatlarini **SSR** qilish va **slug URL**lar — keyingi (kattaroq) increment'lar.

## Gate
`npm run lint` ✅ · `npm test` ✅ 159/159 · `npm run i18n:check` ✅ 812 · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)