### PR TITLE
feat(admin): CEO/Founder statistics dashboard at /admin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-leaflet": "^4.2.1",
         "react-scroll-to-top": "^3.1.0",
         "react-slick": "^0.30.2",
+        "recharts": "^2.15.4",
         "slick-carousel": "^1.8.1"
       },
       "devDependencies": {
@@ -4522,6 +4523,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -6694,6 +6758,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6795,6 +6980,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -7900,6 +8091,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
@@ -8735,6 +8935,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/intl-messageformat": {
@@ -9774,6 +9983,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -11761,6 +11976,21 @@
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -11790,6 +12020,51 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -13208,6 +13483,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -13717,6 +13998,28 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-leaflet": "^4.2.1",
     "react-scroll-to-top": "^3.1.0",
     "react-slick": "^0.30.2",
+    "recharts": "^2.15.4",
     "slick-carousel": "^1.8.1"
   },
   "devDependencies": {

--- a/src/app/[locale]/admin/layout.jsx
+++ b/src/app/[locale]/admin/layout.jsx
@@ -1,0 +1,38 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
+import { getUserProfile } from "@/services/auth";
+import LoadingScreen from "@/components/LoadingScreen";
+
+// Staff-gate for the CEO/Founder dashboard. Authentication itself is handled
+// by <ProtectedRoute> (root layout) because "/admin" is in PROTECTED_PAGES —
+// an anonymous visitor is bounced to /login before reaching here. This layer
+// adds the ROLE check: only `is_staff` users may see the dashboard. The API is
+// independently enforced server-side (IsAdminUser), so this is UX, not security.
+export default function AdminLayout({ children }) {
+  const router = useRouter();
+  const tLoad = useTranslations("Loading");
+  const [state, setState] = useState("checking"); // checking | allowed
+
+  useEffect(() => {
+    let active = true;
+    getUserProfile()
+      .then(({ user }) => {
+        if (!active) return;
+        if (user?.is_staff) setState("allowed");
+        else router.replace("/");
+      })
+      .catch(() => {
+        if (active) router.replace("/");
+      });
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  if (state !== "allowed") {
+    return <LoadingScreen title={tLoad("loading")} />;
+  }
+  return <>{children}</>;
+}

--- a/src/app/[locale]/admin/page.jsx
+++ b/src/app/[locale]/admin/page.jsx
@@ -1,0 +1,11 @@
+import AdminDashboard from "@/components/admin/AdminDashboard";
+
+// Internal staff tool — never index, never follow.
+export const metadata = {
+  title: "Boshqaruv paneli — Kitobzor",
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default function AdminPage() {
+  return <AdminDashboard />;
+}

--- a/src/components/admin/AdminDashboard.jsx
+++ b/src/components/admin/AdminDashboard.jsx
@@ -1,0 +1,423 @@
+"use client";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  CircularProgress,
+  Stack,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tabs,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fetchSummary, fetchFunnel, fetchDemand, fetchSupply } from "@/services/admin";
+
+const RANGES = [7, 30, 90];
+const CHART_COLORS = ["#6abf7d", "#f4a261", "#4aa3df", "#e9c46a", "#9b8cff", "#ef8a8a"];
+
+// --- small primitives ------------------------------------------------------
+function KpiCard({ label, value, accent }) {
+  return (
+    <Card variant="outlined" sx={{ borderRadius: 3, height: "100%" }}>
+      <CardContent sx={{ p: { xs: 2, md: 2.5 } }}>
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+          {label}
+        </Typography>
+        <Typography variant="h5" sx={{ fontWeight: 700, color: accent || "text.primary", mt: 0.5 }}>
+          {Number(value ?? 0).toLocaleString()}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Panel({ title, children }) {
+  return (
+    <Card variant="outlined" sx={{ borderRadius: 3, height: "100%" }}>
+      <CardContent sx={{ p: { xs: 2, md: 2.5 } }}>
+        {title && (
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1.5 }}>
+            {title}
+          </Typography>
+        )}
+        {children}
+      </CardContent>
+    </Card>
+  );
+}
+
+// Responsive 12-col-ish grid using CSS grid (no Bootstrap, no MUI Grid v9 churn).
+function Cols({ children, min = 240 }) {
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gap: 2,
+        gridTemplateColumns: { xs: "1fr", sm: `repeat(auto-fill, minmax(${min}px, 1fr))` },
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function HBars({ data }) {
+  // data: [{label, value}]
+  if (!data?.length) return null;
+  return (
+    <ResponsiveContainer width="100%" height={Math.max(160, data.length * 34)}>
+      <BarChart data={data} layout="vertical" margin={{ left: 8, right: 16 }}>
+        <CartesianGrid horizontal={false} strokeOpacity={0.2} />
+        <XAxis type="number" allowDecimals={false} fontSize={12} />
+        <YAxis type="category" dataKey="label" width={120} fontSize={12} />
+        <Tooltip />
+        <Bar dataKey="value" radius={[0, 6, 6, 0]}>
+          {data.map((_, i) => (
+            <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function Donut({ data }) {
+  if (!data?.length) return null;
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <PieChart>
+        <Pie data={data} dataKey="value" nameKey="label" outerRadius={80} innerRadius={45}>
+          {data.map((_, i) => (
+            <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip />
+        <Legend />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}
+
+// --- sections --------------------------------------------------------------
+function SummarySection({ data, t }) {
+  const k = data?.kpis || {};
+  const series = data?.series || [];
+  return (
+    <Stack spacing={2}>
+      <Cols>
+        <KpiCard label={t("kpi.totalUsers")} value={k.total_users} accent="#4aa3df" />
+        <KpiCard label={t("kpi.newUsers")} value={k.new_users} accent="#6abf7d" />
+        <KpiCard label={t("kpi.activeBooks")} value={k.active_books} accent="#f4a261" />
+        <KpiCard label={t("kpi.newBooks")} value={k.new_books} accent="#6abf7d" />
+        <KpiCard label={t("kpi.totalShops")} value={k.total_shops} accent="#9b8cff" />
+        <KpiCard label={t("kpi.bannedBooks")} value={k.banned_books} accent="#ef8a8a" />
+      </Cols>
+      <Panel title={t("growth.title")}>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={series} margin={{ left: 0, right: 8 }}>
+            <CartesianGrid strokeOpacity={0.2} />
+            <XAxis dataKey="date" fontSize={11} minTickGap={24} />
+            <YAxis allowDecimals={false} fontSize={11} width={32} />
+            <Tooltip />
+            <Legend />
+            <Line
+              type="monotone"
+              dataKey="new_users"
+              name={t("growth.newUsers")}
+              stroke="#4aa3df"
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="new_books"
+              name={t("growth.newBooks")}
+              stroke="#6abf7d"
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="active_users"
+              name={t("growth.activeUsers")}
+              stroke="#f4a261"
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </Panel>
+    </Stack>
+  );
+}
+
+function FunnelSection({ data, t }) {
+  const tot = data?.totals || {};
+  const rates = data?.rates || {};
+  const steps = [
+    { label: t("funnel.views"), value: tot.views || 0 },
+    { label: t("funnel.contacts"), value: tot.contacts || 0 },
+    { label: t("funnel.shares"), value: tot.shares || 0 },
+  ];
+  const bySource = data?.by_source || {};
+  const sourceData = Object.entries(bySource).map(([src, v]) => ({
+    label: src === "bot" ? t("funnel.bot") : t("funnel.web"),
+    contact: v.contact || 0,
+    gift_share: v.gift_share || 0,
+    wish_share: v.wish_share || 0,
+  }));
+  return (
+    <Stack spacing={2}>
+      <Cols>
+        <KpiCard label={t("funnel.views")} value={tot.views} accent="#4aa3df" />
+        <KpiCard label={t("funnel.contacts")} value={tot.contacts} accent="#f4a261" />
+        <KpiCard label={t("funnel.shares")} value={tot.shares} accent="#6abf7d" />
+        <KpiCard
+          label={t("funnel.viewToContact")}
+          value={`${rates.view_to_contact ?? 0}%`}
+          accent="#9b8cff"
+        />
+        <KpiCard
+          label={t("funnel.viewToShare")}
+          value={`${rates.view_to_share ?? 0}%`}
+          accent="#9b8cff"
+        />
+      </Cols>
+      <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" } }}>
+        <Panel title={t("tabs.funnel")}>
+          <HBars data={steps} />
+        </Panel>
+        <Panel title={t("funnel.bySource")}>
+          <ResponsiveContainer width="100%" height={Math.max(180, sourceData.length * 70)}>
+            <BarChart data={sourceData}>
+              <CartesianGrid strokeOpacity={0.2} />
+              <XAxis dataKey="label" fontSize={12} />
+              <YAxis allowDecimals={false} fontSize={12} width={32} />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="contact" name={t("funnel.contacts")} fill="#f4a261" />
+              <Bar dataKey="gift_share" name={t("funnel.gift")} fill="#6abf7d" />
+              <Bar dataKey="wish_share" name={t("funnel.wish")} fill="#4aa3df" />
+            </BarChart>
+          </ResponsiveContainer>
+        </Panel>
+      </Box>
+    </Stack>
+  );
+}
+
+function DemandTable({ rows, t, showAvg }) {
+  if (!rows?.length) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        {t("empty")}
+      </Typography>
+    );
+  }
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>{t("demand.query")}</TableCell>
+            <TableCell align="right">{t("demand.count")}</TableCell>
+            {showAvg && <TableCell align="right">{t("demand.avgResults")}</TableCell>}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((r, i) => (
+            <TableRow key={`${r.query}-${i}`}>
+              <TableCell sx={{ wordBreak: "break-word" }}>{r.query}</TableCell>
+              <TableCell align="right">{r.count}</TableCell>
+              {showAvg && <TableCell align="right">{r.avg_results}</TableCell>}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+function DemandSection({ data, t }) {
+  return (
+    <Stack spacing={2}>
+      <Cols>
+        <KpiCard label={t("demand.totalSearches")} value={data?.total_searches} accent="#4aa3df" />
+        <KpiCard label={t("demand.distinct")} value={data?.distinct_queries} accent="#9b8cff" />
+        <KpiCard label={t("demand.gaps")} value={data?.gaps?.length} accent="#ef8a8a" />
+      </Cols>
+      <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" } }}>
+        <Panel title={t("demand.topSearches")}>
+          <DemandTable rows={data?.top_searches} t={t} showAvg />
+        </Panel>
+        <Panel title={t("demand.gaps")}>
+          <DemandTable rows={data?.gaps} t={t} />
+        </Panel>
+      </Box>
+    </Stack>
+  );
+}
+
+function SupplySection({ data, t }) {
+  return (
+    <Stack spacing={2}>
+      <Cols>
+        <KpiCard label={t("kpi.totalBooks")} value={data?.totals?.total} accent="#4aa3df" />
+        <KpiCard label={t("kpi.activeBooks")} value={data?.totals?.active} accent="#6abf7d" />
+        <KpiCard
+          label={t("supply.bannedRatio")}
+          value={`${data?.banned_ratio ?? 0}%`}
+          accent="#ef8a8a"
+        />
+      </Cols>
+      <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" } }}>
+        <Panel title={t("supply.byType")}>
+          <Donut data={data?.books_by_type} />
+        </Panel>
+        <Panel title={t("supply.byCondition")}>
+          <Donut data={data?.books_by_condition} />
+        </Panel>
+        <Panel title={t("supply.topSellers")}>
+          <HBars data={data?.top_sellers} />
+        </Panel>
+        <Panel title={t("supply.topShops")}>
+          <HBars data={data?.top_shops} />
+        </Panel>
+        <Panel title={t("supply.topCategories")}>
+          <HBars data={data?.top_categories} />
+        </Panel>
+        <Panel title={t("supply.topRegions")}>
+          <HBars data={data?.top_regions} />
+        </Panel>
+      </Box>
+    </Stack>
+  );
+}
+
+const TABS = [
+  { key: "summary", fetcher: fetchSummary, Section: SummarySection },
+  { key: "funnel", fetcher: fetchFunnel, Section: FunnelSection },
+  { key: "demand", fetcher: fetchDemand, Section: DemandSection },
+  { key: "supply", fetcher: fetchSupply, Section: SupplySection },
+];
+
+export default function AdminDashboard() {
+  const t = useTranslations("Admin");
+  const [tab, setTab] = useState(0);
+  const [days, setDays] = useState(30);
+  const [cache, setCache] = useState({}); // `${key}:${days}` -> data
+  const [status, setStatus] = useState("idle"); // idle | loading | error
+
+  const active = TABS[tab];
+  const cacheKey = `${active.key}:${days}`;
+  const data = cache[cacheKey];
+
+  const load = useCallback(
+    (signal) => {
+      setStatus("loading");
+      active
+        .fetcher({ days, signal })
+        .then((res) => {
+          setCache((prev) => ({ ...prev, [cacheKey]: res }));
+          setStatus("idle");
+        })
+        .catch((err) => {
+          if (err?.code === "ERR_CANCELED" || err?.name === "CanceledError") return;
+          setStatus("error");
+        });
+    },
+    [active, cacheKey, days],
+  );
+
+  useEffect(() => {
+    if (data !== undefined) return; // already cached for this key
+    const controller = new AbortController();
+    load(controller.signal);
+    return () => controller.abort();
+  }, [data, load]);
+
+  const Section = active.Section;
+  const showSection = useMemo(() => data !== undefined, [data]);
+
+  return (
+    <Box sx={{ maxWidth: 1280, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 2, md: 4 } }}>
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        justifyContent="space-between"
+        alignItems={{ xs: "flex-start", sm: "center" }}
+        spacing={2}
+        sx={{ mb: 3 }}
+      >
+        <Box>
+          <Typography variant="h4" sx={{ fontWeight: 700 }}>
+            {t("title")}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t("subtitle")}
+          </Typography>
+        </Box>
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={days}
+          onChange={(_e, v) => v && setDays(v)}
+          aria-label={t("subtitle")}
+        >
+          {RANGES.map((r) => (
+            <ToggleButton key={r} value={r}>
+              {t(`range.${r}`)}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Stack>
+
+      <Tabs
+        value={tab}
+        onChange={(_e, v) => setTab(v)}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{ mb: 3, borderBottom: 1, borderColor: "divider" }}
+      >
+        {TABS.map((tabDef) => (
+          <Tab key={tabDef.key} label={t(`tabs.${tabDef.key}`)} />
+        ))}
+      </Tabs>
+
+      {status === "error" && (
+        <Alert severity="error" sx={{ mb: 2 }} action={<button onClick={() => load()}>↻</button>}>
+          {t("error")}
+        </Alert>
+      )}
+
+      {status === "loading" && !showSection ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        showSection && <Section data={data} t={t} />
+      )}
+    </Box>
+  );
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -12,7 +12,7 @@ export const SUPPORT_PHONE = getSupportPhone();
 // `/user` is gated because the backend `/auth/<id>/` endpoint requires auth
 // (user-enumeration / H-1 privacy protection) — anonymous visitors would
 // otherwise hit a 401→login loop.
-export const PROTECTED_PAGES = ["/account", "/wishlist", "/user"];
+export const PROTECTED_PAGES = ["/account", "/wishlist", "/user", "/admin"];
 
 // Legacy export — kept so callers that imported PUBLIC_PAGES still work.
 // Login / register surfaces are always reachable by definition; we list them
@@ -108,5 +108,13 @@ export const API_ENDPOINTS = {
     ACTIVE: "api/v1/book/give-away/active/",
     LIST: "api/v1/give-away/",
     DETAIL: "api/v1/give-away", // prefix
+  },
+  // Staff-only CEO/Founder dashboard. The backend enforces `IsAdminUser`
+  // (is_staff); the /admin route is additionally role-gated client-side for UX.
+  ADMIN: {
+    SUMMARY: "api/v1/analytics/dashboard/summary/",
+    FUNNEL: "api/v1/analytics/dashboard/funnel/",
+    DEMAND: "api/v1/analytics/dashboard/demand/",
+    SUPPLY: "api/v1/analytics/dashboard/supply/",
   },
 };

--- a/src/lib/http.js
+++ b/src/lib/http.js
@@ -36,6 +36,9 @@ const TTL_MAP = [
   ["/like", 0],
   ["/comment", 0],
   ["/my-list", 0],
+  // Founder dashboard — short cache so a tab switch / range toggle is snappy
+  // without serving stale ops data or hammering the aggregation queries.
+  ["/analytics/dashboard/", 60 * 1000], // 60 s
   // Static-ish content
   ["/regions", 24 * 60 * 60 * 1000], // 24 h — almost never changes
   ["/faqs", 24 * 60 * 60 * 1000], // 24 h

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1007,5 +1007,69 @@
   "Vendor": {
     "searchPlaceholder": "Search shops by name...",
     "showingResults": "Showing {start}-{end} of {total} results"
+  },
+  "Admin": {
+    "title": "Admin dashboard",
+    "subtitle": "CEO / Founder statistics",
+    "loading": "Loading...",
+    "error": "Failed to load data",
+    "empty": "No data",
+    "range": {
+      "7": "7 days",
+      "30": "30 days",
+      "90": "90 days"
+    },
+    "tabs": {
+      "summary": "Overview",
+      "funnel": "Funnel",
+      "demand": "Demand",
+      "supply": "Supply"
+    },
+    "kpi": {
+      "totalUsers": "Total users",
+      "newUsers": "New (period)",
+      "activeUsers": "Active",
+      "totalBooks": "Total books",
+      "activeBooks": "Active books",
+      "newBooks": "New books",
+      "totalShops": "Shops",
+      "bannedBooks": "Banned"
+    },
+    "growth": {
+      "title": "Growth (daily)",
+      "newUsers": "New users",
+      "newBooks": "New books",
+      "activeUsers": "Active users"
+    },
+    "funnel": {
+      "views": "Views",
+      "contacts": "Contacts",
+      "shares": "Shares",
+      "gift": "Gift",
+      "wish": "Wish",
+      "viewToContact": "View→Contact",
+      "viewToShare": "View→Share",
+      "bySource": "By source",
+      "web": "Web",
+      "bot": "Bot"
+    },
+    "demand": {
+      "totalSearches": "Total searches",
+      "distinct": "Distinct queries",
+      "topSearches": "Top searches",
+      "gaps": "Unmet demand (no results)",
+      "query": "Query",
+      "count": "Count",
+      "avgResults": "Avg results"
+    },
+    "supply": {
+      "byType": "By type",
+      "byCondition": "By condition",
+      "topSellers": "Top sellers",
+      "topShops": "Top shops",
+      "topCategories": "Top categories",
+      "topRegions": "Top regions",
+      "bannedRatio": "Banned ratio"
+    }
   }
 }

--- a/src/messages/kaa.json
+++ b/src/messages/kaa.json
@@ -1007,5 +1007,69 @@
   "Vendor": {
     "searchPlaceholder": "Dúken atı boyınsha izleń...",
     "showingResults": "Kórsetilbekte: {start}-{end} / {total}"
+  },
+  "Admin": {
+    "title": "Boshqaruv paneli",
+    "subtitle": "CEO / Founder uchun statistika",
+    "loading": "Yuklanmoqda...",
+    "error": "Ma'lumotni yuklab bo'lmadi",
+    "empty": "Ma'lumot yo'q",
+    "range": {
+      "7": "7 kun",
+      "30": "30 kun",
+      "90": "90 kun"
+    },
+    "tabs": {
+      "summary": "Umumiy",
+      "funnel": "Funnel",
+      "demand": "Talab",
+      "supply": "Taklif"
+    },
+    "kpi": {
+      "totalUsers": "Jami foydalanuvchi",
+      "newUsers": "Yangi (davr)",
+      "activeUsers": "Faol",
+      "totalBooks": "Jami kitob",
+      "activeBooks": "Faol kitob",
+      "newBooks": "Yangi kitob",
+      "totalShops": "Do'konlar",
+      "bannedBooks": "Bloklangan"
+    },
+    "growth": {
+      "title": "O'sish (kunlik)",
+      "newUsers": "Yangi foydalanuvchi",
+      "newBooks": "Yangi kitob",
+      "activeUsers": "Faol foydalanuvchi"
+    },
+    "funnel": {
+      "views": "Ko'rishlar",
+      "contacts": "Kontaktlar",
+      "shares": "Ulashishlar",
+      "gift": "Sovg'a",
+      "wish": "Tilak",
+      "viewToContact": "Ko'rish→Kontakt",
+      "viewToShare": "Ko'rish→Ulashish",
+      "bySource": "Manba bo'yicha",
+      "web": "Veb",
+      "bot": "Bot"
+    },
+    "demand": {
+      "totalSearches": "Jami qidiruv",
+      "distinct": "Noyob so'rov",
+      "topSearches": "Top qidiruvlar",
+      "gaps": "Talab bo'shlig'i (natijasiz)",
+      "query": "So'rov",
+      "count": "Soni",
+      "avgResults": "O'rtacha natija"
+    },
+    "supply": {
+      "byType": "Tur bo'yicha",
+      "byCondition": "Holat bo'yicha",
+      "topSellers": "Top sotuvchilar",
+      "topShops": "Top do'konlar",
+      "topCategories": "Top kategoriyalar",
+      "topRegions": "Top hududlar",
+      "bannedRatio": "Bloklangan ulush"
+    }
   }
 }

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -1007,5 +1007,69 @@
   "Vendor": {
     "searchPlaceholder": "Поиск магазинов по названию...",
     "showingResults": "Показано: {start}-{end} из {total}"
+  },
+  "Admin": {
+    "title": "Панель управления",
+    "subtitle": "Статистика для CEO / Founder",
+    "loading": "Загрузка...",
+    "error": "Не удалось загрузить данные",
+    "empty": "Нет данных",
+    "range": {
+      "7": "7 дней",
+      "30": "30 дней",
+      "90": "90 дней"
+    },
+    "tabs": {
+      "summary": "Обзор",
+      "funnel": "Воронка",
+      "demand": "Спрос",
+      "supply": "Предложение"
+    },
+    "kpi": {
+      "totalUsers": "Всего пользователей",
+      "newUsers": "Новые (период)",
+      "activeUsers": "Активные",
+      "totalBooks": "Всего книг",
+      "activeBooks": "Активные книги",
+      "newBooks": "Новые книги",
+      "totalShops": "Магазины",
+      "bannedBooks": "Заблокировано"
+    },
+    "growth": {
+      "title": "Рост (по дням)",
+      "newUsers": "Новые пользователи",
+      "newBooks": "Новые книги",
+      "activeUsers": "Активные пользователи"
+    },
+    "funnel": {
+      "views": "Просмотры",
+      "contacts": "Контакты",
+      "shares": "Поделились",
+      "gift": "Подарок",
+      "wish": "Желание",
+      "viewToContact": "Просмотр→Контакт",
+      "viewToShare": "Просмотр→Поделиться",
+      "bySource": "По источнику",
+      "web": "Веб",
+      "bot": "Бот"
+    },
+    "demand": {
+      "totalSearches": "Всего поисков",
+      "distinct": "Уникальные запросы",
+      "topSearches": "Топ запросов",
+      "gaps": "Неудовлетворённый спрос",
+      "query": "Запрос",
+      "count": "Кол-во",
+      "avgResults": "Сред. результатов"
+    },
+    "supply": {
+      "byType": "По типу",
+      "byCondition": "По состоянию",
+      "topSellers": "Топ продавцов",
+      "topShops": "Топ магазинов",
+      "topCategories": "Топ категорий",
+      "topRegions": "Топ регионов",
+      "bannedRatio": "Доля заблокированных"
+    }
   }
 }

--- a/src/messages/uz.json
+++ b/src/messages/uz.json
@@ -1007,5 +1007,69 @@
   "Vendor": {
     "searchPlaceholder": "Do'kon nomi bo'yicha qidiring...",
     "showingResults": "Ko'rsatilmoqda: {start}-{end} / {total}"
+  },
+  "Admin": {
+    "title": "Boshqaruv paneli",
+    "subtitle": "CEO / Founder uchun statistika",
+    "loading": "Yuklanmoqda...",
+    "error": "Ma'lumotni yuklab bo'lmadi",
+    "empty": "Ma'lumot yo'q",
+    "range": {
+      "7": "7 kun",
+      "30": "30 kun",
+      "90": "90 kun"
+    },
+    "tabs": {
+      "summary": "Umumiy",
+      "funnel": "Funnel",
+      "demand": "Talab",
+      "supply": "Taklif"
+    },
+    "kpi": {
+      "totalUsers": "Jami foydalanuvchi",
+      "newUsers": "Yangi (davr)",
+      "activeUsers": "Faol",
+      "totalBooks": "Jami kitob",
+      "activeBooks": "Faol kitob",
+      "newBooks": "Yangi kitob",
+      "totalShops": "Do'konlar",
+      "bannedBooks": "Bloklangan"
+    },
+    "growth": {
+      "title": "O'sish (kunlik)",
+      "newUsers": "Yangi foydalanuvchi",
+      "newBooks": "Yangi kitob",
+      "activeUsers": "Faol foydalanuvchi"
+    },
+    "funnel": {
+      "views": "Ko'rishlar",
+      "contacts": "Kontaktlar",
+      "shares": "Ulashishlar",
+      "gift": "Sovg'a",
+      "wish": "Tilak",
+      "viewToContact": "Ko'rish→Kontakt",
+      "viewToShare": "Ko'rish→Ulashish",
+      "bySource": "Manba bo'yicha",
+      "web": "Veb",
+      "bot": "Bot"
+    },
+    "demand": {
+      "totalSearches": "Jami qidiruv",
+      "distinct": "Noyob so'rov",
+      "topSearches": "Top qidiruvlar",
+      "gaps": "Talab bo'shlig'i (natijasiz)",
+      "query": "So'rov",
+      "count": "Soni",
+      "avgResults": "O'rtacha natija"
+    },
+    "supply": {
+      "byType": "Tur bo'yicha",
+      "byCondition": "Holat bo'yicha",
+      "topSellers": "Top sotuvchilar",
+      "topShops": "Top do'konlar",
+      "topCategories": "Top kategoriyalar",
+      "topRegions": "Top hududlar",
+      "bannedRatio": "Bloklangan ulush"
+    }
   }
 }

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -1,0 +1,32 @@
+import http from "@/lib/http";
+import { API_ENDPOINTS } from "@/config";
+import { normalizeItem } from "@/utils/normalizeResponse";
+
+// CEO/Founder dashboard reads. Each endpoint returns the standard envelope
+// `{ result: {...}, success: true }`; `normalizeItem` unwraps `result`.
+// The backend enforces staff access (IsAdminUser) — these calls 403 for
+// non-staff, which the /admin route-gate prevents from ever firing.
+
+async function getSection(url, { days, limit, signal } = {}) {
+  const params = {};
+  if (days) params.days = days;
+  if (limit) params.limit = limit;
+  const { data } = await http.get(url, { params, signal });
+  return normalizeItem(data);
+}
+
+export function fetchSummary(opts) {
+  return getSection(API_ENDPOINTS.ADMIN.SUMMARY, opts);
+}
+
+export function fetchFunnel(opts) {
+  return getSection(API_ENDPOINTS.ADMIN.FUNNEL, opts);
+}
+
+export function fetchDemand(opts) {
+  return getSection(API_ENDPOINTS.ADMIN.DEMAND, opts);
+}
+
+export function fetchSupply(opts) {
+  return getSection(API_ENDPOINTS.ADMIN.SUPPLY, opts);
+}

--- a/tests/e2e/admin.spec.js
+++ b/tests/e2e/admin.spec.js
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+
+const STAFF_USER = {
+  id: 1,
+  first_name: "Boss",
+  user_type: "user",
+  role: "admin",
+  is_staff: true,
+};
+const NORMAL_USER = { ...STAFF_USER, role: "simple", is_staff: false };
+
+const SUMMARY = {
+  result: {
+    days: 30,
+    kpis: {
+      total_users: 100,
+      new_users: 5,
+      active_books: 50,
+      new_books: 3,
+      total_shops: 4,
+      banned_books: 1,
+      total_books: 51,
+    },
+    series: [{ date: "2026-06-01", new_users: 1, new_books: 1, active_users: 2 }],
+  },
+  success: true,
+};
+
+function setAuth(page) {
+  return page.evaluate(() => {
+    localStorage.setItem("auth_token", "fake_access_token");
+    localStorage.setItem("refresh_token", "fake_refresh_token");
+    localStorage.setItem("token_expires_at", String(Date.now() + 3_600_000));
+    localStorage.setItem("login_time", String(Date.now()));
+  });
+}
+
+function mockApi(page, user) {
+  return page.route("**/api/v1/**", (route) => {
+    const url = route.request().url();
+    if (url.includes("/auth/me/")) return route.fulfill({ json: user });
+    if (url.includes("/analytics/dashboard/summary/")) return route.fulfill({ json: SUMMARY });
+    return route.fulfill({ json: { result: {}, success: true } });
+  });
+}
+
+test.describe("admin dashboard route gate", () => {
+  test("staff user sees the dashboard", async ({ page }) => {
+    await mockApi(page, STAFF_USER);
+    await page.goto("/uz/");
+    await setAuth(page);
+    await page.goto("/uz/admin");
+    await expect(page.getByText("Boshqaruv paneli")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("non-staff user is redirected away from /admin", async ({ page }) => {
+    await mockApi(page, NORMAL_USER);
+    await page.goto("/uz/");
+    await setAuth(page);
+    await page.goto("/uz/admin");
+    await page.waitForURL((url) => !url.pathname.includes("/admin"), { timeout: 10_000 });
+    expect(page.url()).not.toContain("/admin");
+  });
+});

--- a/tests/unit/admin.service.test.js
+++ b/tests/unit/admin.service.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { get } = vi.hoisted(() => ({ get: vi.fn() }));
+vi.mock("@/lib/http", () => ({ default: { get } }));
+
+import { fetchSummary, fetchFunnel, fetchDemand, fetchSupply } from "@/services/admin";
+import { API_ENDPOINTS } from "@/config";
+
+beforeEach(() => get.mockReset());
+
+describe("admin service", () => {
+  it("fetchSummary unwraps result and passes days", async () => {
+    get.mockResolvedValue({ data: { result: { kpis: { total_users: 5 } }, success: true } });
+    const out = await fetchSummary({ days: 7 });
+    expect(get).toHaveBeenCalledWith(
+      API_ENDPOINTS.ADMIN.SUMMARY,
+      expect.objectContaining({ params: { days: 7 } }),
+    );
+    expect(out).toEqual({ kpis: { total_users: 5 } });
+  });
+
+  it("fetchDemand passes both days and limit", async () => {
+    get.mockResolvedValue({ data: { result: { gaps: [] }, success: true } });
+    await fetchDemand({ days: 30, limit: 10 });
+    expect(get).toHaveBeenCalledWith(
+      API_ENDPOINTS.ADMIN.DEMAND,
+      expect.objectContaining({ params: { days: 30, limit: 10 } }),
+    );
+  });
+
+  it("fetchFunnel returns raw data when there is no result wrapper", async () => {
+    get.mockResolvedValue({ data: { foo: 1 } });
+    expect(await fetchFunnel()).toEqual({ foo: 1 });
+  });
+
+  it("fetchSupply calls the supply endpoint", async () => {
+    get.mockResolvedValue({ data: { result: {}, success: true } });
+    await fetchSupply({ days: 90 });
+    expect(get).toHaveBeenCalledWith(
+      API_ENDPOINTS.ADMIN.SUPPLY,
+      expect.objectContaining({ params: { days: 90 } }),
+    );
+  });
+
+  it("omits empty params", async () => {
+    get.mockResolvedValue({ data: { result: {}, success: true } });
+    await fetchSummary();
+    expect(get).toHaveBeenCalledWith(
+      API_ENDPOINTS.ADMIN.SUMMARY,
+      expect.objectContaining({ params: {} }),
+    );
+  });
+});


### PR DESCRIPTION
## What
A staff-only **/admin** dashboard that visualises the analytics the backend now exposes:

- **Summary** — headline KPIs + daily growth/active-users line chart
- **Funnel** — view → contact → share conversion + web/bot split
- **Demand** — top searches + zero-result demand gaps
- **Supply** — inventory by type/condition, top sellers/shops/categories/regions
- 7 / 30 / 90-day range toggle

## How
- Auth-gated via `PROTECTED_PAGES` (`/admin`) and additionally **role-gated** in `admin/layout.jsx` (checks `is_staff` from `/auth/me/`; backend enforces too).
- Data via `src/services/admin.js` (envelope-normalized), 60s HTTP cache TTL.
- Charts: **recharts** (React-18 compatible, MUI-independent — avoids `@mui/material@9` X-charts version coupling).
- Mobile-first MUI `sx`, CSS-grid layout, no fixed sizes. i18n `Admin` namespace across uz/ru/en/kaa (`i18n:check` green).

## Tests
- Vitest `tests/unit/admin.service.test.js` (5) + Playwright `tests/e2e/admin.spec.js` route-gate smoke (staff sees dashboard, non-staff redirected).
- **Full suite 164 passed, lint clean, `next build` green** (`/admin` route compiles, recharts bundled).

## Manual test plan
Log in as staff → `/uz/admin` renders 4 tabs with live data; 7/30/90-day toggle refetches; non-staff `/admin` redirects home; layout OK at 360 / 768 / 1440px.

**API:** consumes `/api/v1/analytics/dashboard/{summary,funnel,demand,supply}/` (backend: menOtabek/kitobzor#97-series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)