### PR TITLE
feat(auth): refresh via HttpOnly cookie (C-4, partial)

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -24,6 +24,14 @@ export const PUBLIC_PAGES = ["/login", "/register", "/forgot-password", "/auth/a
 
 export const AUTH_TOKEN_STORAGE_KEY = "auth_token";
 
+// C-4 (partial): the 14-day refresh token lives in an HttpOnly cookie set by
+// the backend, NOT in localStorage — so XSS can't exfiltrate it. The backend
+// is additive (still accepts a body refresh token), so flipping this to
+// `false` + rebuilding cleanly reverts to the old body-token behaviour
+// (instant-ish rollback). The short-lived access token stays in localStorage
+// + Authorization header, so the rest of the auth flow is unchanged.
+export const COOKIE_REFRESH = true;
+
 export const API_ENDPOINTS = {
   AUTH: {
     // Trailing slashes are MANDATORY — Django's APPEND_SLASH issues a 301

--- a/src/lib/http.js
+++ b/src/lib/http.js
@@ -87,7 +87,11 @@ const httpClient = axios.create({
     "Content-Type": "application/json",
     Accept: "application/json",
   },
-  withCredentials: false,
+  // Send/receive the HttpOnly refresh cookie (C-4). Only the path-scoped
+  // `kz_refresh` cookie (/api/v1/auth/) actually rides any request; other
+  // endpoints set no cookies, so this is effectively free elsewhere. The
+  // backend allows credentials for the explicit FE origin (CORS).
+  withCredentials: true,
   timeout: 20000,
 });
 

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,5 +1,5 @@
 import http from "@/lib/http";
-import { AUTH_TOKEN_STORAGE_KEY, API_ENDPOINTS } from "@/config";
+import { AUTH_TOKEN_STORAGE_KEY, API_ENDPOINTS, COOKIE_REFRESH } from "@/config";
 import { setItem, getItem } from "@/utils/storage";
 import { clearAuthStorage } from "@/utils/authStorage";
 import { withIdempotency } from "@/lib/idempotency";
@@ -41,7 +41,9 @@ export async function loginWithPhoneOtp({ phone_number, otp_code }) {
     setItem("login_time", Date.now());
   }
 
-  if (refreshToken) {
+  // C-4: in cookie mode the refresh token arrives via an HttpOnly Set-Cookie,
+  // so we never persist it in JS-readable storage. Body mode keeps the old path.
+  if (refreshToken && !COOKIE_REFRESH) {
     setItem("refresh_token", refreshToken);
   }
 
@@ -79,7 +81,9 @@ export async function loginWithCode(otp_code) {
     saveAccessToken(accessToken, expiresIn);
     setItem("login_time", Date.now());
   }
-  if (refreshToken) {
+  // C-4: in cookie mode the refresh token arrives via an HttpOnly Set-Cookie,
+  // so we never persist it in JS-readable storage. Body mode keeps the old path.
+  if (refreshToken && !COOKIE_REFRESH) {
     setItem("refresh_token", refreshToken);
   }
 
@@ -131,6 +135,12 @@ export function isTokenExpired() {
 }
 
 export function isRefreshTokenExpired() {
+  // Cookie mode: the refresh token is HttpOnly — JS can't read it to inspect
+  // its `exp`. Treat it as "maybe valid" and let the server be the authority:
+  // a refresh attempt either succeeds or returns 401, which the 401 handler /
+  // ProtectedRoute already turn into a login redirect.
+  if (COOKIE_REFRESH) return false;
+
   const refreshToken = getItem("refresh_token");
   if (!refreshToken) return true;
 
@@ -161,15 +171,18 @@ export function refreshAccessToken() {
 }
 
 async function _doRefreshAccessToken() {
-  const refreshToken = getItem("refresh_token");
-  if (!refreshToken) throw new Error("No refresh token");
+  // Cookie mode: the HttpOnly `kz_refresh` cookie authenticates the refresh —
+  // there's no JS-readable refresh token to gate on or send. Body mode keeps
+  // reading/sending it from localStorage.
+  const refreshToken = COOKIE_REFRESH ? null : getItem("refresh_token");
+  if (!COOKIE_REFRESH && !refreshToken) throw new Error("No refresh token");
 
   devLog("🔄 Refreshing access token");
 
   try {
     const { data } = await http.post(
       API_ENDPOINTS.AUTH.REFRESH,
-      { refresh_token: refreshToken },
+      COOKIE_REFRESH ? {} : { refresh_token: refreshToken },
       { skipAuthRefresh: true },
     );
 
@@ -177,7 +190,7 @@ async function _doRefreshAccessToken() {
       saveAccessToken(data.access_token, data?.expires_in || data?.expires_in_seconds);
     }
 
-    if (data?.refresh_token) {
+    if (data?.refresh_token && !COOKIE_REFRESH) {
       setItem("refresh_token", data.refresh_token);
     }
 
@@ -214,7 +227,9 @@ export async function loginWithTicket(ticket) {
     saveAccessToken(accessToken, expiresIn);
     setItem("login_time", Date.now());
   }
-  if (refreshToken) {
+  // C-4: in cookie mode the refresh token arrives via an HttpOnly Set-Cookie,
+  // so we never persist it in JS-readable storage. Body mode keeps the old path.
+  if (refreshToken && !COOKIE_REFRESH) {
     setItem("refresh_token", refreshToken);
   }
   return {
@@ -248,6 +263,11 @@ export async function logoutUser() {
 export function isAuthenticated() {
   const token = getItem(AUTH_TOKEN_STORAGE_KEY);
   if (token) return true;
+
+  // Cookie mode: the refresh token is invisible to JS, so use `login_time`
+  // (set on login, cleared on logout) as an optimistic "has a session" marker.
+  // The server validates it on the next request / refresh.
+  if (COOKIE_REFRESH) return !!getItem("login_time");
 
   const refreshToken = getItem("refresh_token");
   return !!refreshToken && !isRefreshTokenExpired();

--- a/tests/unit/cookieAuth.test.js
+++ b/tests/unit/cookieAuth.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// C-4: refresh token lives in an HttpOnly cookie. These tests pin the
+// frontend's cookie-mode behaviour (COOKIE_REFRESH === true).
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+const store = vi.hoisted(() => ({ map: {} }));
+
+vi.mock("@/lib/http", () => ({
+  default: { post, defaults: { headers: { common: {} } } },
+}));
+vi.mock("@/utils/storage", () => ({
+  setItem: vi.fn((k, v) => {
+    store.map[k] = v;
+  }),
+  getItem: vi.fn((k) => (k in store.map ? store.map[k] : null)),
+  removeItem: vi.fn((k) => {
+    delete store.map[k];
+  }),
+}));
+vi.mock("@/utils/authStorage", () => ({ clearAuthStorage: vi.fn() }));
+vi.mock("@/lib/idempotency", () => ({ withIdempotency: (c = {}) => c }));
+
+import { COOKIE_REFRESH } from "@/config";
+import { setItem } from "@/utils/storage";
+import { refreshAccessToken, loginWithPhoneOtp, isRefreshTokenExpired } from "@/services/auth";
+
+beforeEach(() => {
+  post.mockReset();
+  setItem.mockClear();
+  store.map = {};
+});
+
+describe("cookie-mode auth (C-4)", () => {
+  it("the cookie-refresh flag is enabled", () => {
+    expect(COOKIE_REFRESH).toBe(true);
+  });
+
+  it("refresh posts an empty body — the HttpOnly cookie authenticates it", async () => {
+    post.mockResolvedValue({ data: { access_token: "AAA", expires_in: 4800 } });
+    await refreshAccessToken();
+    const [url, body, cfg] = post.mock.calls[0];
+    expect(url).toContain("refresh");
+    expect(body).toEqual({});
+    expect(cfg.skipAuthRefresh).toBe(true);
+  });
+
+  it("login persists the access token but NOT the refresh token", async () => {
+    post.mockResolvedValue({
+      data: { access_token: "AAA", refresh_token: "RRR", expires_in_seconds: 4800 },
+    });
+    await loginWithPhoneOtp({ phone_number: "+998900000000", otp_code: "123456" });
+    const keys = setItem.mock.calls.map((c) => c[0]);
+    expect(keys).toContain("auth_token");
+    expect(keys).toContain("login_time");
+    expect(keys).not.toContain("refresh_token");
+  });
+
+  it("isRefreshTokenExpired defers to the server (false) in cookie mode", () => {
+    expect(isRefreshTokenExpired()).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Pairs with the backend: the 14-day refresh token now rides an **HttpOnly cookie**, so XSS can't exfiltrate it for persistent account takeover. Gated by `COOKIE_REFRESH` (default on; flip + rebuild = instant revert to body mode).

## Changes
- `http.js`: `withCredentials: true` so the path-scoped `kz_refresh` cookie travels (only `/api/v1/auth/` carries it; other endpoints set no cookies).
- `auth.js` (cookie mode): refresh `POST`s an **empty body** (cookie authenticates); login/refresh **stop persisting** `refresh_token` in localStorage; `isRefreshTokenExpired` defers to the server (returns `false`, the existing 401 handler does the redirect); `isAuthenticated` uses `login_time` as the optimistic session marker.
- **Unchanged**: `useAuth`, `ProtectedRoute`, the 401-refresh queue (access token still in localStorage + `Authorization` header).

## Tests
`tests/unit/cookieAuth.test.js` (4): empty-body refresh, no `refresh_token` persisted, `isRefreshTokenExpired` false in cookie mode. Full suite **168 passed**, lint clean, `next build` green.

## Manual test plan
Log in → works; DevTools → `kz_refresh` is **HttpOnly** and **absent from `document.cookie`**; force a 401 → silent cookie refresh; logout → cookie cleared + re-login required. Bot login/search unaffected.

**API:** backend menOtabek/kitobzor#<this PR>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)