### PR TITLE
feat: post books as a shop + 'more from this seller' on book detail

### DIFF
--- a/src/components/BookCreateModal.jsx
+++ b/src/components/BookCreateModal.jsx
@@ -145,7 +145,7 @@ const StepHeading = ({ title, subtitle }) => (
   </Box>
 );
 
-const BookCreateModal = ({ isOpen, onClose, onSuccess, editBook = null }) => {
+const BookCreateModal = ({ isOpen, onClose, onSuccess, editBook = null, initialShopId = null }) => {
   const t = useTranslations("BookCreateModal");
   const tCommon = useTranslations("Common");
   const tType = useTranslations("BookTypeChips");
@@ -185,6 +185,14 @@ const BookCreateModal = ({ isOpen, onClose, onSuccess, editBook = null }) => {
     if (!isOpen || editBook || !draft) return;
     setFormData((prev) => ({ ...prev, ...draft }));
   }, [isOpen, editBook, draft]);
+
+  // Launched from a shop page → pre-attribute to that shop. Runs after the
+  // draft restore so it wins over a stale personal draft's `shop`. The owner
+  // step still renders (so the user can see/change it), defaulting to the shop.
+  useEffect(() => {
+    if (!isOpen || editBook || !initialShopId) return;
+    setFormData((prev) => ({ ...prev, shop: String(initialShopId) }));
+  }, [isOpen, editBook, initialShopId]);
 
   // Hydrate from `editBook` once when modal opens.
   useEffect(() => {

--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -27,6 +27,7 @@ import Icon from "@/components/Icon";
 import { getContactActions } from "@/utils/contactActions";
 import { mapValidationError } from "@/lib/mapValidationError";
 import BookCreateModal from "./BookCreateModal";
+import MoreFromSellerSection from "./MoreFromSellerSection";
 import { useToast } from "./Toast";
 
 const BookDetails = ({ bookId }) => {
@@ -754,6 +755,9 @@ const BookDetails = ({ bookId }) => {
             />
           )}
         </Stack>
+
+        {/* ─── More from this seller (user or shop) ─────────────────── */}
+        <MoreFromSellerSection bookId={book.id} />
 
         {/* Edit modal */}
         <BookCreateModal

--- a/src/components/MoreFromSellerSection.jsx
+++ b/src/components/MoreFromSellerSection.jsx
@@ -1,0 +1,105 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import Icon from "@/components/Icon";
+import BookRowGrid from "@/components/shared/BookRowGrid";
+import { getSellerBooks } from "@/services/books";
+
+/**
+ * "More from this seller" — the bottom block on a book detail page. One call to
+ * `getSellerBooks(bookId)` resolves whether the seller is a user or a shop and
+ * returns up to 5 OTHER active books, the total count, and a seller descriptor.
+ * The "see all" link points at the seller's full catalog (shop detail / public
+ * user profile). The whole section self-hides when the seller has no other
+ * books, so it never renders an empty shell.
+ */
+export default function MoreFromSellerSection({ bookId }) {
+  const t = useTranslations("BookDetails");
+  const [loading, setLoading] = useState(true);
+  const [seller, setSeller] = useState(null);
+  const [count, setCount] = useState(0);
+  const [books, setBooks] = useState([]);
+
+  useEffect(() => {
+    if (!bookId) return undefined;
+    let alive = true;
+    setLoading(true);
+    getSellerBooks(bookId, 5)
+      .then((res) => {
+        if (!alive) return;
+        setSeller(res.seller);
+        setCount(res.count);
+        setBooks(res.books);
+      })
+      .catch(() => {
+        if (alive) setBooks([]);
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [bookId]);
+
+  // Resolved with no other books → hide the section entirely (no empty box).
+  if (!loading && books.length === 0) return null;
+
+  const seeAllHref =
+    seller?.kind === "shop"
+      ? `/shops/${seller.id}`
+      : seller?.kind === "user"
+        ? `/user/${seller.id}`
+        : null;
+
+  const heading =
+    seller?.kind === "shop" ? t("moreFromShop", { name: seller?.name || "" }) : t("moreFromUser");
+
+  return (
+    <Box component="section" sx={{ mt: { xs: 4, md: 5 } }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ mb: 2, gap: 1, flexWrap: "wrap" }}
+      >
+        <Typography
+          component="h2"
+          sx={{
+            fontSize: { xs: 17, md: 20 },
+            fontWeight: 700,
+            color: "var(--text-primary)",
+            m: 0,
+          }}
+        >
+          {heading}
+        </Typography>
+
+        {seeAllHref && count > 0 && (
+          <Link
+            href={seeAllHref}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              fontSize: 14,
+              fontWeight: 600,
+              color: "var(--main-600, #2e7d32)",
+              textDecoration: "none",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {t("seeAll")}
+            {count > books.length ? ` (${count})` : ""}
+            <Icon className="ph ph-arrow-right" aria-hidden="true" />
+          </Link>
+        )}
+      </Stack>
+
+      <BookRowGrid books={books} loading={loading} skeletonCount={3} />
+    </Box>
+  );
+}

--- a/src/components/PostBookMount.jsx
+++ b/src/components/PostBookMount.jsx
@@ -15,9 +15,12 @@ const BookCreateModal = dynamic(() => import("./BookCreateModal"), {
 export default function PostBookMount() {
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
+  // Pre-selected shop when launched from a shop page (else null = personal).
+  const [initialShopId, setInitialShopId] = useState(null);
 
   useEffect(() => {
-    const handler = () => {
+    const handler = (e) => {
+      setInitialShopId(e?.detail?.shopId ?? null);
       setMounted(true);
       setOpen(true);
     };
@@ -29,6 +32,7 @@ export default function PostBookMount() {
   return (
     <BookCreateModal
       isOpen={open}
+      initialShopId={initialShopId}
       onClose={() => setOpen(false)}
       onSuccess={() => setOpen(false)}
     />

--- a/src/components/ShopDetailPage.jsx
+++ b/src/components/ShopDetailPage.jsx
@@ -18,6 +18,7 @@ import {
 import dynamic from "next/dynamic";
 import { getShopDetails } from "@/services/shop";
 import { getBooks } from "@/services/books";
+import { openPostBookFromShopModal } from "@/lib/postBookModal";
 import { getBookCategories, getBookSubcategories } from "@/services/categories";
 import BookRowGrid from "@/components/shared/BookRowGrid";
 import { openShareSheet } from "@/lib/shareSheet";
@@ -531,6 +532,21 @@ const ShopDetailPage = ({ shopId }) => {
                     >
                       <Icon className="ph ph-globe" />
                     </IconButton>
+                  )}
+                  {shop?.can_update && (
+                    <Button
+                      onClick={() => openPostBookFromShopModal(shop.id)}
+                      variant="contained"
+                      size="small"
+                      startIcon={<Icon className="ph ph-plus" aria-hidden="true" />}
+                      sx={{
+                        textTransform: "none",
+                        fontWeight: 700,
+                        borderRadius: 999,
+                      }}
+                    >
+                      {t("addBook")}
+                    </Button>
                   )}
                   {shop?.can_update && (
                     <Button

--- a/src/lib/postBookModal.js
+++ b/src/lib/postBookModal.js
@@ -8,7 +8,18 @@ const EVENT = "post-book-modal:open";
 
 export function openPostBookModal() {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent(EVENT));
+  // No shopId → personal listing (the modal still lets owners pick a shop).
+  window.dispatchEvent(new CustomEvent(EVENT, { detail: { shopId: null } }));
+}
+
+/**
+ * Open the modal pre-attributed to a specific shop — used from the owner's
+ * shop page so "add book here" lists under the shop automatically. The backend
+ * still validates that the caller owns/staffs the shop.
+ */
+export function openPostBookFromShopModal(shopId) {
+  if (typeof window === "undefined" || !shopId) return;
+  window.dispatchEvent(new CustomEvent(EVENT, { detail: { shopId: String(shopId) } }));
 }
 
 export const POST_BOOK_MODAL_EVENT = EVENT;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -318,7 +318,10 @@
     "giftWish": "Ask someone to gift me",
     "giftGive": "Gift it to someone",
     "giftWishText": "📚 I'd love to read “{name}” — it would make me so happy if someone gifted it to me 🎁",
-    "giftGiveText": "📖 I'd like to gift you “{name}” — would you read it?"
+    "giftGiveText": "📖 I'd like to gift you “{name}” — would you read it?",
+    "seeAll": "See all",
+    "moreFromShop": "More books from {name}",
+    "moreFromUser": "More from this seller"
   },
   "BookCard": {
     "noName": "Book Name Not Available",
@@ -818,7 +821,8 @@
     "telegram": "Telegram",
     "openingHours": "Hours",
     "lunchBreak": "Lunch",
-    "workingDays": "Working days"
+    "workingDays": "Working days",
+    "addBook": "Add book"
   },
   "BooksPage": {
     "title": {

--- a/src/messages/kaa.json
+++ b/src/messages/kaa.json
@@ -318,7 +318,10 @@
     "giftWish": "Maǵan sıylıq etsin",
     "giftGive": "Jaqınıńızǵa sıylıq etiń",
     "giftWishText": "📚 «{name}» kitabın oqıǵım keledi — kimde-kim maǵan sıylıq etse, júdá quwanar edim 🎁",
-    "giftGiveText": "📖 Saǵan «{name}» kitabın sıylıq etpekshimen, oqıysań ba?"
+    "giftGiveText": "📖 Saǵan «{name}» kitabın sıylıq etpekshimen, oqıysań ba?",
+    "seeAll": "Hámmesin kóriw",
+    "moreFromShop": "{name} dúkanınan basqa kitaplar",
+    "moreFromUser": "Bul satıwshıdan basqa kitaplar"
   },
   "BookCard": {
     "noName": "Kitap Atı Joq",
@@ -818,7 +821,8 @@
     "telegram": "Telegram",
     "openingHours": "Jumıs waqtı",
     "lunchBreak": "Túslik",
-    "workingDays": "Jumıs kúnleri"
+    "workingDays": "Jumıs kúnleri",
+    "addBook": "Kitap qosıw"
   },
   "BooksPage": {
     "title": {

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -318,7 +318,10 @@
     "giftWish": "Хочу получить в подарок",
     "giftGive": "Подарить близкому",
     "giftWishText": "📚 Хочу прочитать книгу «{name}» — будет здорово, если кто-нибудь подарит мне её 🎁",
-    "giftGiveText": "📖 Хочу подарить тебе книгу «{name}», прочитаешь?"
+    "giftGiveText": "📖 Хочу подарить тебе книгу «{name}», прочитаешь?",
+    "seeAll": "Смотреть все",
+    "moreFromShop": "Другие книги магазина «{name}»",
+    "moreFromUser": "Другие книги этого продавца"
   },
   "BookCard": {
     "noName": "Название книги отсутствует",
@@ -818,7 +821,8 @@
     "telegram": "Telegram",
     "openingHours": "Часы работы",
     "lunchBreak": "Обед",
-    "workingDays": "Рабочие дни"
+    "workingDays": "Рабочие дни",
+    "addBook": "Добавить книгу"
   },
   "BooksPage": {
     "title": {

--- a/src/messages/uz.json
+++ b/src/messages/uz.json
@@ -318,7 +318,10 @@
     "giftWish": "Menga sovg'a qilishsin",
     "giftGive": "Yaqiningizga sovg'a qiling",
     "giftWishText": "📚 «{name}» kitobini o'qimoqchiman — kimdir menga sovg'a qilsa juda xursand bo'lardim 🎁",
-    "giftGiveText": "📖 Senga «{name}» kitobini sovg'a qilmoqchiman, o'qiysanmi?"
+    "giftGiveText": "📖 Senga «{name}» kitobini sovg'a qilmoqchiman, o'qiysanmi?",
+    "seeAll": "Hammasini ko'rish",
+    "moreFromShop": "{name} do'konidan boshqa kitoblar",
+    "moreFromUser": "Ushbu sotuvchidan boshqa kitoblar"
   },
   "BookCard": {
     "noName": "Kitob Nomi Mavjud Emas",
@@ -818,7 +821,8 @@
     "telegram": "Telegram",
     "openingHours": "Ish vaqti",
     "lunchBreak": "Tushlik",
-    "workingDays": "Ish kunlari"
+    "workingDays": "Ish kunlari",
+    "addBook": "Kitob qo'shish"
   },
   "BooksPage": {
     "title": {

--- a/src/services/books.js
+++ b/src/services/books.js
@@ -71,6 +71,25 @@ export async function getBookById(id) {
 }
 
 /**
+ * "More from this seller" — up to `limit` OTHER active books from the same
+ * seller as `bookId` (the posting user, or the shop for a shop listing), plus a
+ * seller descriptor ({ kind: "user"|"shop", id, name }) and the total count for
+ * a "see all" link. One call; the backend resolves user-vs-shop and excludes
+ * the current book.
+ */
+export async function getSellerBooks(bookId, limit = 5) {
+  const { data } = await http.get(`${API_ENDPOINTS.BOOKS.DETAIL}/${bookId}/seller-books/`, {
+    params: { limit },
+  });
+  const result = data?.result ?? {};
+  return {
+    seller: result.seller ?? null,
+    count: typeof result.count === "number" ? result.count : 0,
+    books: Array.isArray(result.results) ? result.results : [],
+  };
+}
+
+/**
  * Notify the admin channel that a website visitor tapped a contact button on
  * this book (call / SMS / Telegram). Fire-and-forget: a logging failure must
  * never block the user's actual contact action, so errors are swallowed. The

--- a/tests/unit/sellerBooks.service.test.js
+++ b/tests/unit/sellerBooks.service.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { get } = vi.hoisted(() => ({ get: vi.fn() }));
+vi.mock("@/lib/http", () => ({ default: { get }, clearHttpCache: vi.fn() }));
+
+import { getSellerBooks } from "@/services/books";
+import { API_ENDPOINTS } from "@/config";
+
+beforeEach(() => get.mockReset());
+
+describe("getSellerBooks", () => {
+  it("hits the seller-books action with a limit and unwraps seller/count/results", async () => {
+    get.mockResolvedValue({
+      data: {
+        result: {
+          seller: { kind: "shop", id: 7, name: "Kitob Shop" },
+          count: 12,
+          results: [{ id: 2 }, { id: 3 }],
+        },
+        success: true,
+      },
+    });
+
+    const out = await getSellerBooks(9, 5);
+
+    expect(get).toHaveBeenCalledWith(
+      `${API_ENDPOINTS.BOOKS.DETAIL}/9/seller-books/`,
+      expect.objectContaining({ params: { limit: 5 } }),
+    );
+    expect(out.seller).toEqual({ kind: "shop", id: 7, name: "Kitob Shop" });
+    expect(out.count).toBe(12);
+    expect(out.books).toHaveLength(2);
+  });
+
+  it("returns safe defaults when the payload is empty/malformed", async () => {
+    get.mockResolvedValue({ data: { success: true } });
+    const out = await getSellerBooks(1);
+    expect(out).toEqual({ seller: null, count: 0, books: [] });
+  });
+});


### PR DESCRIPTION
## Feature 1 — post a book as a shop
- `ShopDetailPage` owner area (`can_update`) gets an **"Add book"** primary button.
- `openPostBookFromShopModal(shopId)` → `PostBookMount` → `BookCreateModal` opens with `initialShopId` pre-selected, so the listing defaults to that shop. Posting from the profile stays personal. Backend (menOtabek/kitobzor#102 already had it) validates shop ownership and sets `owner_type=SHOP`.

## Feature 2 — "more from this seller" on book detail
- New `MoreFromSellerSection`: one `getSellerBooks(bookId)` call → 5 other books from the same seller (user **or** shop), rendered in the shared responsive `BookRowGrid`, with a **"See all (N)"** link to `/shops/<id>` or `/user/<id>`. Self-hides when there are no other books.
- New `getSellerBooks()` service hitting the backend `seller-books` action.

## i18n
`ShopDetailPage.addBook`, `BookDetails.{seeAll,moreFromShop,moreFromUser}` across all 4 locales (i18n:check 862 keys in sync).

## Tests
`sellerBooks.service.test.js` (2) → 172 vitest pass. Lint clean, `next build` green.

## Deploy
Frontend image rebuild (baked). Pairs with backend PR #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)