### PR TITLE
feat: show up to 6 'more from this seller' books, then see-all link

### DIFF
--- a/src/components/MoreFromSellerSection.jsx
+++ b/src/components/MoreFromSellerSection.jsx
@@ -11,7 +11,7 @@ import { getSellerBooks } from "@/services/books";
 /**
  * "More from this seller" — the bottom block on a book detail page. One call to
  * `getSellerBooks(bookId)` resolves whether the seller is a user or a shop and
- * returns up to 5 OTHER active books, the total count, and a seller descriptor.
+ * returns up to 6 OTHER active books, the total count, and a seller descriptor.
  * The "see all" link points at the seller's full catalog (shop detail / public
  * user profile). The whole section self-hides when the seller has no other
  * books, so it never renders an empty shell.
@@ -27,7 +27,7 @@ export default function MoreFromSellerSection({ bookId }) {
     if (!bookId) return undefined;
     let alive = true;
     setLoading(true);
-    getSellerBooks(bookId, 5)
+    getSellerBooks(bookId, 6)
       .then((res) => {
         if (!alive) return;
         setSeller(res.seller);
@@ -99,7 +99,7 @@ export default function MoreFromSellerSection({ bookId }) {
         )}
       </Stack>
 
-      <BookRowGrid books={books} loading={loading} skeletonCount={3} />
+      <BookRowGrid books={books} loading={loading} skeletonCount={6} />
     </Box>
   );
 }

--- a/src/services/books.js
+++ b/src/services/books.js
@@ -71,13 +71,13 @@ export async function getBookById(id) {
 }
 
 /**
- * "More from this seller" — up to `limit` OTHER active books from the same
- * seller as `bookId` (the posting user, or the shop for a shop listing), plus a
- * seller descriptor ({ kind: "user"|"shop", id, name }) and the total count for
- * a "see all" link. One call; the backend resolves user-vs-shop and excludes
- * the current book.
+ * "More from this seller" — up to `limit` (default 6) OTHER active books from
+ * the same seller as `bookId` (the posting user, or the shop for a shop
+ * listing), plus a seller descriptor ({ kind: "user"|"shop", id, name }) and
+ * the total count for a "see all" link. One call; the backend resolves
+ * user-vs-shop and excludes the current book.
  */
-export async function getSellerBooks(bookId, limit = 5) {
+export async function getSellerBooks(bookId, limit = 6) {
   const { data } = await http.get(`${API_ENDPOINTS.BOOKS.DETAIL}/${bookId}/seller-books/`, {
     params: { limit },
   });


### PR DESCRIPTION
Bump the in-page cap on the book-detail 'more from this seller' block from 5 to 6 so it fills the 3-column `BookRowGrid` as two clean rows. The 'See all (N)' link already covers the remainder. Frontend-only; backend already honors the `limit` param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)