### PR TITLE
feat: book detail — Details before Description

### DIFF
--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -680,25 +680,10 @@ const BookDetails = ({ bookId }) => {
           </Stack>
         </Stack>
 
-        {/* ─── Description ───────────────────────────────────────────── */}
-        {(localized("description") || book.description) && (
-          <Box sx={{ mt: { xs: 3, md: 5 } }}>
-            <SectionHeading icon="ph-fill ph-book-open" text={tBook("aboutBook")} />
-            <Typography
-              sx={{
-                color: "var(--text-secondary)",
-                lineHeight: 1.65,
-                whiteSpace: "pre-wrap",
-                fontSize: 14.5,
-              }}
-            >
-              {localized("description") || book.description}
-            </Typography>
-          </Box>
-        )}
-
-        {/* ─── Details list — fold of all metadata, single source. ── */}
-        <Box sx={{ mt: { xs: 3, md: 4 } }}>
+        {/* ─── Details list — fold of all metadata, single source. ──
+            Shown BEFORE the description: the at-a-glance facts (language,
+            cover, year, pages, location…) are what a buyer scans first. */}
+        <Box sx={{ mt: { xs: 3, md: 5 } }}>
           <SectionHeading icon="ph-fill ph-list-bullets" text={tBook("detailsTitle")} />
           <Box
             sx={{
@@ -728,6 +713,23 @@ const BookDetails = ({ bookId }) => {
             <DetailRow label={tBook("postedOn")} value={formatDate(book.created_at)} last />
           </Box>
         </Box>
+
+        {/* ─── Description (after the details) ───────────────────────── */}
+        {(localized("description") || book.description) && (
+          <Box sx={{ mt: { xs: 3, md: 4 } }}>
+            <SectionHeading icon="ph-fill ph-book-open" text={tBook("aboutBook")} />
+            <Typography
+              sx={{
+                color: "var(--text-secondary)",
+                lineHeight: 1.65,
+                whiteSpace: "pre-wrap",
+                fontSize: 14.5,
+              }}
+            >
+              {localized("description") || book.description}
+            </Typography>
+          </Box>
+        )}
 
         {/* ─── Stats — small, contextual ───────────────────────────── */}
         <Stack


### PR DESCRIPTION
Reorder the book-detail metadata blocks: the at-a-glance **Details** list now renders before the free-text **About the book** description. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)