### PR TITLE
feat: book collections (bundles) — wizard, cards, detail, management

### DIFF
--- a/src/app/[locale]/collection/[id]/page.jsx
+++ b/src/app/[locale]/collection/[id]/page.jsx
@@ -1,0 +1,34 @@
+import dynamic from "next/dynamic";
+import CollectionDetails from "@/components/CollectionDetails";
+import ColorInit from "@/helper/ColorInit";
+import ScrollToTopInit from "@/helper/ScrollToTopInit";
+import { serverGet } from "@/lib/serverFetch";
+
+const FooterOne = dynamic(() => import("@/components/FooterOne"));
+
+export const revalidate = 300;
+
+export async function generateMetadata({ params }) {
+  const { id, locale } = await params;
+  try {
+    const res = await serverGet(`/api/v1/book/collections/${id}/`, { locale, revalidate: 120 });
+    const c = res?.result || res || {};
+    return { title: c?.title ? `${c.title} — Kitobzor` : "Kitobzor", robots: { index: true } };
+  } catch {
+    return { title: "Kitobzor" };
+  }
+}
+
+const page = async ({ params }) => {
+  const { id } = await params;
+  return (
+    <>
+      <ScrollToTopInit color="#299E60" />
+      <ColorInit color={false} />
+      <CollectionDetails collectionId={id} />
+      <FooterOne />
+    </>
+  );
+};
+
+export default page;

--- a/src/app/[locale]/collections/page.jsx
+++ b/src/app/[locale]/collections/page.jsx
@@ -1,0 +1,19 @@
+import dynamic from "next/dynamic";
+import CollectionsListPage from "@/components/CollectionsListPage";
+import ColorInit from "@/helper/ColorInit";
+import ScrollToTopInit from "@/helper/ScrollToTopInit";
+
+const FooterOne = dynamic(() => import("@/components/FooterOne"));
+
+export const metadata = { title: "Kitob to'plamlari — Kitobzor" };
+
+export default function Page() {
+  return (
+    <>
+      <ScrollToTopInit color="#299E60" />
+      <ColorInit color={false} />
+      <CollectionsListPage />
+      <FooterOne />
+    </>
+  );
+}

--- a/src/app/[locale]/page.jsx
+++ b/src/app/[locale]/page.jsx
@@ -4,6 +4,7 @@ import BannerOne from "@/components/BannerOne";
 import HomeMainEntryChips from "@/components/home/HomeMainEntryChips";
 import HomeStoryBar from "@/components/home/HomeStoryBar";
 import HomeShopsRow from "@/components/home/HomeShopsRow";
+import HomeCollectionsRow from "@/components/home/HomeCollectionsRow";
 import HomeBookList from "@/components/home/HomeBookList";
 import ColorInit from "@/helper/ColorInit";
 import ScrollToTopInit from "@/helper/ScrollToTopInit";
@@ -65,6 +66,8 @@ export async function generateMetadata({ params }) {
 
 const bookParams = (type) => ({
   is_active: true,
+  // Hide books bundled into a collection — they show once as a collection card.
+  standalone: true,
   type,
   owner_type: "user",
   // 6 so the home feed fills exactly two full rows of the 3-column BookRowGrid
@@ -107,6 +110,7 @@ const page = async ({ params }) => {
       <HomeMainEntryChips />
       <HomeStoryBar initialStories={initialStories} />
       <HomeShopsRow initialShops={initialShops} />
+      <HomeCollectionsRow />
 
       <HomeBookList
         type="sell"

--- a/src/components/BookCreateModal.jsx
+++ b/src/components/BookCreateModal.jsx
@@ -145,7 +145,16 @@ const StepHeading = ({ title, subtitle }) => (
   </Box>
 );
 
-const BookCreateModal = ({ isOpen, onClose, onSuccess, editBook = null, initialShopId = null }) => {
+const BookCreateModal = ({
+  isOpen,
+  onClose,
+  onSuccess,
+  editBook = null,
+  initialShopId = null,
+  // When true (collection wizard) the owner step is hidden so every book in a
+  // bundle stays under the same owner; `initialShopId` (null = personal) wins.
+  lockShop = false,
+}) => {
   const t = useTranslations("BookCreateModal");
   const tCommon = useTranslations("Common");
   const tType = useTranslations("BookTypeChips");
@@ -429,7 +438,7 @@ const BookCreateModal = ({ isOpen, onClose, onSuccess, editBook = null, initialS
       },
       {
         key: "owner",
-        when: () => shops.length > 0,
+        when: () => shops.length > 0 && !lockShop,
         title: t("step.ownerTitle"),
         subtitle: t("step.ownerSubtitle"),
         validate: () => true,

--- a/src/components/CollectionCreateModal.jsx
+++ b/src/components/CollectionCreateModal.jsx
@@ -1,0 +1,457 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Box,
+  Stack,
+  Typography,
+  Button,
+  IconButton,
+  TextField,
+  Alert,
+} from "@mui/material";
+import { useTranslations, useLocale } from "next-intl";
+import Icon from "@/components/Icon";
+import { createCollection } from "@/services/collections";
+import { getBooks } from "@/services/books";
+import { formatPrice } from "@/utils/formatPrice";
+import { resolveMediaUrl } from "@/utils/mediaUrl";
+import BookCreateModal from "./BookCreateModal";
+import { useToast } from "./Toast";
+
+const effectivePrice = (b) => {
+  const v = b?.discount_price || b?.price || 0;
+  const n = typeof v === "string" ? parseFloat(v) : v;
+  return isNaN(n) ? 0 : n;
+};
+
+function currentUserId() {
+  try {
+    const token = localStorage.getItem("auth_token");
+    if (!token) return null;
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return payload.user_id || payload.id || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Bundle wizard. Reuses BookCreateModal to add a NEW book (same per-book flow
+ * as single-book), and an inline picker to add ALREADY-posted standalone
+ * books. A bundle needs ≥2 books; the final step takes the bundle price
+ * (capped at the sum of the individual prices, with a "cheaper is better"
+ * warning).
+ */
+const CollectionCreateModal = ({ isOpen, onClose, onSuccess, initialShopId = null }) => {
+  const t = useTranslations("CollectionCreateModal");
+  const tCommon = useTranslations("Common");
+  const locale = useLocale();
+  const { showToast, ToastContainer } = useToast();
+
+  const [view, setView] = useState("list"); // list | pick | price
+  const [books, setBooks] = useState([]); // chosen member books
+  const [bundlePrice, setBundlePrice] = useState("");
+  const [newBookOpen, setNewBookOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  // existing-book picker
+  const [pickerLoading, setPickerLoading] = useState(false);
+  const [pickerBooks, setPickerBooks] = useState([]);
+  const [pickerSel, setPickerSel] = useState({});
+
+  useEffect(() => {
+    if (!isOpen) {
+      setView("list");
+      setBooks([]);
+      setBundlePrice("");
+      setError(null);
+      setNewBookOpen(false);
+      setPickerSel({});
+    }
+  }, [isOpen]);
+
+  const originalTotal = useMemo(() => books.reduce((s, b) => s + effectivePrice(b), 0), [books]);
+  const chosenIds = useMemo(() => new Set(books.map((b) => b.id)), [books]);
+
+  const addBook = (book) => {
+    if (!book || chosenIds.has(book.id)) return;
+    setBooks((prev) => [...prev, book]);
+  };
+  const removeBook = (id) => setBooks((prev) => prev.filter((b) => b.id !== id));
+
+  // ── existing-book picker ──────────────────────────────────────────────
+  const openPicker = async () => {
+    setView("pick");
+    setPickerLoading(true);
+    try {
+      const params = { standalone: true, is_active: true, limit: 50 };
+      if (initialShopId) {
+        params.shop = initialShopId;
+      } else {
+        const uid = currentUserId();
+        if (uid) {
+          params.posted_by = uid;
+          params.owner_type = "user";
+        }
+      }
+      const { books: list } = await getBooks(params);
+      setPickerBooks(list || []);
+    } catch {
+      setPickerBooks([]);
+    } finally {
+      setPickerLoading(false);
+    }
+  };
+
+  const confirmPicker = () => {
+    const picked = pickerBooks.filter((b) => pickerSel[b.id]);
+    picked.forEach(addBook);
+    setPickerSel({});
+    setView("list");
+  };
+
+  // ── submit ────────────────────────────────────────────────────────────
+  const goToPrice = () => {
+    if (books.length < 2) {
+      setError(t("needTwo"));
+      return;
+    }
+    setError(null);
+    setView("price");
+  };
+
+  const priceNum = bundlePrice === "" ? null : parseFloat(bundlePrice);
+  const priceTooHigh = priceNum != null && originalTotal > 0 && priceNum > originalTotal;
+
+  const submit = async () => {
+    if (priceTooHigh) {
+      setError(t("tooHigh"));
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await createCollection({
+        book_ids: books.map((b) => b.id),
+        bundle_price: bundlePrice === "" ? null : bundlePrice,
+        shop: initialShopId,
+      });
+      if (res.success !== false && res.collection) {
+        showToast({
+          type: "success",
+          title: tCommon("success"),
+          message: t("created"),
+          duration: 3000,
+        });
+        onSuccess?.(res.collection);
+        onClose?.();
+      } else {
+        setError(res.raw?.result || t("error"));
+      }
+    } catch (e) {
+      setError(e?.normalized?.message || e?.message || t("error"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const fullScreen = typeof window !== "undefined" && window.innerWidth < 900;
+
+  return (
+    <>
+      <Dialog
+        open={isOpen && !newBookOpen}
+        onClose={onClose}
+        fullWidth
+        maxWidth="sm"
+        fullScreen={fullScreen}
+        PaperProps={{ sx: { borderRadius: { xs: 0, md: 3 } } }}
+      >
+        <DialogTitle
+          sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", pr: 1 }}
+        >
+          <Typography component="span" sx={{ fontWeight: 700, fontSize: 18 }}>
+            {view === "price" ? t("priceTitle") : view === "pick" ? t("pickTitle") : t("title")}
+          </Typography>
+          <IconButton onClick={onClose} size="small" aria-label={tCommon("cancel")}>
+            <Icon className="ph ph-x" />
+          </IconButton>
+        </DialogTitle>
+
+        <DialogContent dividers>
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
+
+          {/* ── LIST VIEW ── */}
+          {view === "list" && (
+            <Stack spacing={1.5}>
+              <Typography variant="body2" sx={{ color: "var(--text-muted)" }}>
+                {t("listHint")}
+              </Typography>
+
+              {books.length === 0 ? (
+                <Box sx={{ textAlign: "center", py: 3, color: "var(--text-muted)" }}>
+                  <Icon className="ph ph-stack" style={{ fontSize: 40 }} aria-hidden="true" />
+                  <Typography sx={{ mt: 1, fontSize: 14 }}>{t("empty")}</Typography>
+                </Box>
+              ) : (
+                <Stack spacing={1}>
+                  {books.map((b, i) => (
+                    <Stack
+                      key={b.id}
+                      direction="row"
+                      spacing={1.5}
+                      sx={{
+                        alignItems: "center",
+                        p: 1,
+                        borderRadius: 2,
+                        border: "1px solid var(--border-subtle)",
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          width: 40,
+                          height: 52,
+                          borderRadius: 1,
+                          overflow: "hidden",
+                          bgcolor: "var(--surface-muted)",
+                          flexShrink: 0,
+                        }}
+                      >
+                        {b.picture && (
+                          // eslint-disable-next-line @next/next/no-img-element -- tiny thumb
+                          <img
+                            src={resolveMediaUrl(b.picture)}
+                            alt=""
+                            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                          />
+                        )}
+                      </Box>
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography noWrap sx={{ fontWeight: 600, fontSize: 14 }}>
+                          {i + 1}. {b.name}
+                        </Typography>
+                        <Typography sx={{ fontSize: 12.5, color: "var(--main-600)" }}>
+                          {formatPrice(effectivePrice(b), locale)}
+                        </Typography>
+                      </Box>
+                      <IconButton
+                        size="small"
+                        onClick={() => removeBook(b.id)}
+                        aria-label={tCommon("delete")}
+                      >
+                        <Icon
+                          className="ph ph-trash"
+                          style={{ fontSize: 18, color: "var(--danger-600, #dc2626)" }}
+                        />
+                      </IconButton>
+                    </Stack>
+                  ))}
+                </Stack>
+              )}
+
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+                <Button
+                  variant="outlined"
+                  startIcon={<Icon className="ph ph-plus" />}
+                  onClick={() => setNewBookOpen(true)}
+                  sx={{ textTransform: "none", borderRadius: 2, flex: 1 }}
+                >
+                  {t("addNew")}
+                </Button>
+                <Button
+                  variant="outlined"
+                  startIcon={<Icon className="ph ph-books" />}
+                  onClick={openPicker}
+                  sx={{ textTransform: "none", borderRadius: 2, flex: 1 }}
+                >
+                  {t("addExisting")}
+                </Button>
+              </Stack>
+
+              <Button
+                variant="contained"
+                disabled={books.length < 2}
+                onClick={goToPrice}
+                sx={{ textTransform: "none", borderRadius: 2, fontWeight: 700, mt: 1 }}
+              >
+                {t("continue")} {books.length >= 2 ? `(${books.length})` : ""}
+              </Button>
+            </Stack>
+          )}
+
+          {/* ── PICK EXISTING VIEW ── */}
+          {view === "pick" && (
+            <Stack spacing={1}>
+              {pickerLoading ? (
+                <Typography sx={{ py: 3, textAlign: "center", color: "var(--text-muted)" }}>
+                  {tCommon("loading")}
+                </Typography>
+              ) : pickerBooks.filter((b) => !chosenIds.has(b.id)).length === 0 ? (
+                <Typography sx={{ py: 3, textAlign: "center", color: "var(--text-muted)" }}>
+                  {t("noExisting")}
+                </Typography>
+              ) : (
+                pickerBooks
+                  .filter((b) => !chosenIds.has(b.id))
+                  .map((b) => {
+                    const sel = !!pickerSel[b.id];
+                    return (
+                      <Stack
+                        key={b.id}
+                        direction="row"
+                        spacing={1.5}
+                        onClick={() => setPickerSel((p) => ({ ...p, [b.id]: !p[b.id] }))}
+                        sx={{
+                          alignItems: "center",
+                          p: 1,
+                          borderRadius: 2,
+                          cursor: "pointer",
+                          border: `1px solid ${sel ? "var(--main-600, #2e7d32)" : "var(--border-subtle)"}`,
+                          bgcolor: sel ? "var(--main-50, #e6f4ea)" : "transparent",
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            width: 36,
+                            height: 48,
+                            borderRadius: 1,
+                            overflow: "hidden",
+                            bgcolor: "var(--surface-muted)",
+                            flexShrink: 0,
+                          }}
+                        >
+                          {b.picture && (
+                            // eslint-disable-next-line @next/next/no-img-element -- tiny thumb
+                            <img
+                              src={resolveMediaUrl(b.picture)}
+                              alt=""
+                              style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                            />
+                          )}
+                        </Box>
+                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                          <Typography noWrap sx={{ fontWeight: 600, fontSize: 13.5 }}>
+                            {b.name}
+                          </Typography>
+                          <Typography sx={{ fontSize: 12, color: "var(--main-600)" }}>
+                            {formatPrice(effectivePrice(b), locale)}
+                          </Typography>
+                        </Box>
+                        <Icon
+                          className={sel ? "ph-fill ph-check-circle" : "ph ph-circle"}
+                          style={{
+                            fontSize: 22,
+                            color: sel ? "var(--main-600)" : "var(--text-muted)",
+                          }}
+                        />
+                      </Stack>
+                    );
+                  })
+              )}
+              <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                <Button
+                  variant="text"
+                  onClick={() => setView("list")}
+                  sx={{ textTransform: "none" }}
+                >
+                  {tCommon("back")}
+                </Button>
+                <Button
+                  variant="contained"
+                  onClick={confirmPicker}
+                  disabled={Object.values(pickerSel).every((v) => !v)}
+                  sx={{ textTransform: "none", borderRadius: 2, flex: 1 }}
+                >
+                  {t("addSelected")}
+                </Button>
+              </Stack>
+            </Stack>
+          )}
+
+          {/* ── PRICE VIEW ── */}
+          {view === "price" && (
+            <Stack spacing={2}>
+              <Box sx={{ p: 1.5, borderRadius: 2, bgcolor: "var(--surface-muted)" }}>
+                <Stack direction="row" justifyContent="space-between">
+                  <Typography sx={{ fontSize: 13.5, color: "var(--text-muted)" }}>
+                    {t("sumLabel")}
+                  </Typography>
+                  <Typography sx={{ fontSize: 14, fontWeight: 700 }}>
+                    {formatPrice(originalTotal, locale)}
+                  </Typography>
+                </Stack>
+                <Typography sx={{ fontSize: 12, color: "var(--text-muted)", mt: 0.5 }}>
+                  {t("sumHint", { count: books.length })}
+                </Typography>
+              </Box>
+
+              <TextField
+                label={t("bundlePrice")}
+                value={bundlePrice}
+                onChange={(e) => setBundlePrice(e.target.value.replace(/[^\d.]/g, ""))}
+                inputMode="decimal"
+                fullWidth
+                size="small"
+                error={priceTooHigh}
+                helperText={priceTooHigh ? t("tooHigh") : t("cheaperHint")}
+              />
+
+              {priceNum != null &&
+                !priceTooHigh &&
+                originalTotal > 0 &&
+                priceNum < originalTotal && (
+                  <Alert severity="success" sx={{ py: 0.5 }}>
+                    {t("savings", { amount: formatPrice(originalTotal - priceNum, locale) })}
+                  </Alert>
+                )}
+
+              <Stack direction="row" spacing={1}>
+                <Button
+                  variant="text"
+                  onClick={() => setView("list")}
+                  sx={{ textTransform: "none" }}
+                >
+                  {tCommon("back")}
+                </Button>
+                <Button
+                  variant="contained"
+                  onClick={submit}
+                  disabled={submitting || priceTooHigh}
+                  sx={{ textTransform: "none", borderRadius: 2, fontWeight: 700, flex: 1 }}
+                >
+                  {submitting ? tCommon("loading") : t("create")}
+                </Button>
+              </Stack>
+            </Stack>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Nested per-book create — reuses the exact single-book flow */}
+      {newBookOpen && (
+        <BookCreateModal
+          isOpen={newBookOpen}
+          initialShopId={initialShopId}
+          lockShop
+          onClose={() => setNewBookOpen(false)}
+          onSuccess={(book) => {
+            if (book) addBook(book);
+            setNewBookOpen(false);
+          }}
+        />
+      )}
+      <ToastContainer />
+    </>
+  );
+};
+
+export default CollectionCreateModal;

--- a/src/components/CollectionDetails.jsx
+++ b/src/components/CollectionDetails.jsx
@@ -1,0 +1,468 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import { useTranslations, useLocale } from "next-intl";
+import {
+  Box,
+  Stack,
+  Typography,
+  Chip,
+  Button,
+  IconButton,
+  Menu,
+  MenuItem,
+  CircularProgress,
+} from "@mui/material";
+import { Link, useRouter } from "@/i18n/navigation";
+import Icon from "@/components/Icon";
+import { formatPrice } from "@/utils/formatPrice";
+import { resolveMediaUrl } from "@/utils/mediaUrl";
+import {
+  getCollectionById,
+  deleteCollection,
+  detachBookFromCollection,
+  moveBookToCollection,
+  getCollectionsByUser,
+  getCollectionsByShop,
+} from "@/services/collections";
+import { useToast } from "./Toast";
+
+const MONTAGE_CELL = { width: "50%", height: "50%", position: "absolute", overflow: "hidden" };
+const CELL_POS = [
+  { top: 0, left: 0 },
+  { top: 0, right: 0 },
+  { bottom: 0, left: 0 },
+  { bottom: 0, right: 0 },
+];
+
+export default function CollectionDetails({ collectionId }) {
+  const t = useTranslations("CollectionDetails");
+  const tCommon = useTranslations("Common");
+  const locale = useLocale();
+  const router = useRouter();
+  const { showToast, ToastContainer } = useToast();
+
+  const [collection, setCollection] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [managing, setManaging] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [moveMenu, setMoveMenu] = useState({ anchor: null, bookId: null });
+  const [targets, setTargets] = useState([]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { collection: c } = await getCollectionById(collectionId);
+      setCollection(c);
+    } catch {
+      setCollection(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [collectionId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (!collection) {
+    return (
+      <Box sx={{ textAlign: "center", py: 8, color: "var(--text-muted)" }}>
+        <Typography>{t("notFound")}</Typography>
+      </Box>
+    );
+  }
+
+  const books = collection.books || [];
+  const covers = (
+    collection.covers && collection.covers.length
+      ? collection.covers
+      : books.map((b) => b.picture).filter(Boolean)
+  ).slice(0, 4);
+  const bundle = collection.bundle_price;
+  const original = collection.original_total;
+  const pct = collection.discount_percent;
+  const canUpdate = collection.can_update;
+  const seller = collection.shop
+    ? { kind: "shop", id: collection.shop.id, name: collection.shop.name }
+    : collection.posted_by
+      ? {
+          kind: "user",
+          id: collection.posted_by.id,
+          name: [collection.posted_by.first_name, collection.posted_by.last_name]
+            .filter(Boolean)
+            .join(" "),
+        }
+      : null;
+
+  const openMove = async (e, bookId) => {
+    setMoveMenu({ anchor: e.currentTarget, bookId });
+    try {
+      const res =
+        seller?.kind === "shop"
+          ? await getCollectionsByShop(seller.id, 50)
+          : await getCollectionsByUser(seller?.id, 50);
+      setTargets((res.collections || []).filter((c) => c.id !== collection.id));
+    } catch {
+      setTargets([]);
+    }
+  };
+
+  const doDetach = async (bookId) => {
+    setBusy(true);
+    try {
+      await detachBookFromCollection(collection.id, bookId);
+      showToast({
+        type: "success",
+        title: tCommon("success"),
+        message: t("detached"),
+        duration: 2500,
+      });
+      await load();
+    } catch {
+      showToast({
+        type: "error",
+        title: tCommon("error"),
+        message: t("actionFailed"),
+        duration: 3000,
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doMove = async (targetId) => {
+    const bookId = moveMenu.bookId;
+    setMoveMenu({ anchor: null, bookId: null });
+    setBusy(true);
+    try {
+      await moveBookToCollection(collection.id, bookId, targetId);
+      showToast({
+        type: "success",
+        title: tCommon("success"),
+        message: t("moved"),
+        duration: 2500,
+      });
+      await load();
+    } catch {
+      showToast({
+        type: "error",
+        title: tCommon("error"),
+        message: t("actionFailed"),
+        duration: 3000,
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doDelete = async () => {
+    if (typeof window !== "undefined" && !window.confirm(t("deleteConfirm"))) return;
+    setBusy(true);
+    try {
+      await deleteCollection(collection.id);
+      showToast({
+        type: "success",
+        title: tCommon("success"),
+        message: t("deleted"),
+        duration: 2500,
+      });
+      router.push("/collections");
+    } catch {
+      showToast({
+        type: "error",
+        title: tCommon("error"),
+        message: t("actionFailed"),
+        duration: 3000,
+      });
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Box component="section" sx={{ bgcolor: "var(--surface-page)", py: { xs: 2.5, md: 4 } }}>
+      <Box sx={{ maxWidth: 980, mx: "auto", px: { xs: 2, md: 3 } }}>
+        {/* Hero */}
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={{ xs: 2.5, md: 4 }}
+          sx={{ alignItems: "flex-start" }}
+        >
+          <Box
+            sx={{
+              position: "relative",
+              width: { xs: "100%", md: 300 },
+              aspectRatio: "1 / 1",
+              flexShrink: 0,
+              borderRadius: 3,
+              overflow: "hidden",
+              bgcolor: "var(--surface-muted)",
+              border: "1px solid var(--border-subtle)",
+            }}
+          >
+            {covers.length ? (
+              covers.map((src, i) => (
+                <Box key={i} sx={{ ...MONTAGE_CELL, ...CELL_POS[i] }}>
+                  {/* eslint-disable-next-line @next/next/no-img-element -- montage tile */}
+                  <img
+                    src={resolveMediaUrl(src)}
+                    alt=""
+                    style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                  />
+                </Box>
+              ))
+            ) : (
+              <Icon
+                className="ph ph-stack"
+                style={{
+                  fontSize: 56,
+                  color: "var(--text-muted)",
+                  position: "absolute",
+                  inset: 0,
+                  margin: "auto",
+                }}
+              />
+            )}
+          </Box>
+
+          <Stack spacing={1.5} sx={{ flex: 1, minWidth: 0, width: "100%" }}>
+            <Chip
+              size="small"
+              icon={<Icon className="ph-fill ph-stack" style={{ fontSize: 13 }} />}
+              label={t("bundleBadge", { count: books.length })}
+              sx={{
+                alignSelf: "flex-start",
+                fontWeight: 700,
+                bgcolor: "var(--main-50, #e6f4ea)",
+                color: "var(--main-600, #2e7d32)",
+              }}
+            />
+            <Typography
+              component="h1"
+              sx={{
+                fontSize: { xs: 20, md: 24 },
+                fontWeight: 800,
+                lineHeight: 1.25,
+                color: "var(--text-primary)",
+              }}
+            >
+              {collection.title || t("untitled")}
+            </Typography>
+
+            {bundle != null && bundle !== "" && (
+              <Stack
+                direction="row"
+                spacing={1.5}
+                sx={{ alignItems: "baseline", flexWrap: "wrap" }}
+              >
+                <Typography
+                  sx={{
+                    fontSize: { xs: 24, md: 28 },
+                    fontWeight: 800,
+                    color: "var(--main-600, #2e7d32)",
+                  }}
+                >
+                  {formatPrice(bundle, locale)}
+                </Typography>
+                {pct ? (
+                  <>
+                    <Typography
+                      sx={{
+                        fontSize: 15,
+                        color: "var(--text-muted)",
+                        textDecoration: "line-through",
+                      }}
+                    >
+                      {formatPrice(original, locale)}
+                    </Typography>
+                    <Chip
+                      size="small"
+                      label={t("savePercent", { percent: pct })}
+                      sx={{
+                        fontWeight: 700,
+                        bgcolor: "var(--main-50, #e6f4ea)",
+                        color: "var(--main-600, #2e7d32)",
+                      }}
+                    />
+                  </>
+                ) : null}
+              </Stack>
+            )}
+
+            {seller && (
+              <Link
+                href={seller.kind === "shop" ? `/shops/${seller.id}` : `/user/${seller.id}`}
+                style={{
+                  textDecoration: "none",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  color: "var(--text-secondary)",
+                  fontSize: 14,
+                }}
+              >
+                <Icon
+                  className={seller.kind === "shop" ? "ph-fill ph-storefront" : "ph-fill ph-user"}
+                  style={{ fontSize: 16 }}
+                />
+                {seller.name}
+              </Link>
+            )}
+
+            {canUpdate && (
+              <Stack direction="row" spacing={1} sx={{ mt: 0.5, flexWrap: "wrap" }}>
+                <Button
+                  size="small"
+                  variant={managing ? "contained" : "outlined"}
+                  startIcon={<Icon className="ph ph-pencil-simple" />}
+                  onClick={() => setManaging((m) => !m)}
+                  sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+                >
+                  {managing ? t("doneManaging") : t("manage")}
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="error"
+                  startIcon={<Icon className="ph ph-trash" />}
+                  onClick={doDelete}
+                  disabled={busy}
+                  sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+                >
+                  {t("deleteCollection")}
+                </Button>
+              </Stack>
+            )}
+          </Stack>
+        </Stack>
+
+        {/* Member books */}
+        <Box sx={{ mt: { xs: 3, md: 4 } }}>
+          <Typography component="h2" sx={{ fontSize: { xs: 17, md: 20 }, fontWeight: 700, mb: 2 }}>
+            {t("memberBooks", { count: books.length })}
+          </Typography>
+          <Stack spacing={1.25}>
+            {books.map((b) => (
+              <Stack
+                key={b.id}
+                direction="row"
+                spacing={1.5}
+                sx={{
+                  alignItems: "center",
+                  p: 1,
+                  borderRadius: 2.5,
+                  border: "1px solid var(--border-subtle)",
+                  bgcolor: "var(--surface-card)",
+                }}
+              >
+                <Link
+                  href={`/book-details/${b.id}`}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 12,
+                    flex: 1,
+                    minWidth: 0,
+                    textDecoration: "none",
+                    color: "inherit",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 48,
+                      height: 62,
+                      borderRadius: 1.5,
+                      overflow: "hidden",
+                      bgcolor: "var(--surface-muted)",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {b.picture && (
+                      // eslint-disable-next-line @next/next/no-img-element -- thumb
+                      <img
+                        src={resolveMediaUrl(b.picture)}
+                        alt=""
+                        style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                      />
+                    )}
+                  </Box>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography
+                      sx={{
+                        fontWeight: 600,
+                        fontSize: 14,
+                        display: "-webkit-box",
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: "vertical",
+                        overflow: "hidden",
+                      }}
+                    >
+                      {b.name}
+                    </Typography>
+                    {b.author && (
+                      <Typography sx={{ fontSize: 12, color: "var(--text-muted)" }} noWrap>
+                        {b.author}
+                      </Typography>
+                    )}
+                    <Typography sx={{ fontSize: 12.5, color: "var(--main-600)" }}>
+                      {formatPrice(b.discount_price || b.price, locale)}
+                    </Typography>
+                  </Box>
+                </Link>
+                {managing && canUpdate && (
+                  <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => openMove(e, b.id)}
+                      disabled={busy}
+                      title={t("moveBook")}
+                      aria-label={t("moveBook")}
+                    >
+                      <Icon className="ph ph-arrows-left-right" style={{ fontSize: 18 }} />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      onClick={() => doDetach(b.id)}
+                      disabled={busy}
+                      title={t("detachBook")}
+                      aria-label={t("detachBook")}
+                    >
+                      <Icon
+                        className="ph ph-link-break"
+                        style={{ fontSize: 18, color: "var(--danger-600, #dc2626)" }}
+                      />
+                    </IconButton>
+                  </Stack>
+                )}
+              </Stack>
+            ))}
+          </Stack>
+        </Box>
+
+        <Menu
+          anchorEl={moveMenu.anchor}
+          open={Boolean(moveMenu.anchor)}
+          onClose={() => setMoveMenu({ anchor: null, bookId: null })}
+        >
+          {targets.length === 0 ? (
+            <MenuItem disabled>{t("noTargets")}</MenuItem>
+          ) : (
+            targets.map((tc) => (
+              <MenuItem key={tc.id} onClick={() => doMove(tc.id)}>
+                {tc.title || `#${tc.id}`}
+              </MenuItem>
+            ))
+          )}
+        </Menu>
+      </Box>
+      <ToastContainer />
+    </Box>
+  );
+}

--- a/src/components/CollectionsListPage.jsx
+++ b/src/components/CollectionsListPage.jsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Box, Typography } from "@mui/material";
+import { getCollections } from "@/services/collections";
+import CollectionRowGrid from "@/components/shared/CollectionRowGrid";
+
+export default function CollectionsListPage() {
+  const t = useTranslations("CollectionCard");
+  const [collections, setCollections] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    getCollections({ is_active: true, limit: 30 })
+      .then((res) => alive && setCollections(res.collections || []))
+      .catch(() => {})
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <Box
+      component="section"
+      sx={{ bgcolor: "var(--surface-page)", py: { xs: 2.5, md: 4 }, minHeight: "60vh" }}
+    >
+      <Box sx={{ maxWidth: 1240, mx: "auto", px: { xs: 2, md: 3 } }}>
+        <Typography component="h1" sx={{ fontSize: { xs: 20, md: 24 }, fontWeight: 800, mb: 2 }}>
+          {t("homeTitle")}
+        </Typography>
+        <CollectionRowGrid
+          collections={collections}
+          loading={loading}
+          skeletonCount={6}
+          emptyState={
+            <Typography sx={{ color: "var(--text-muted)", py: 4, textAlign: "center" }}>
+              {t("none")}
+            </Typography>
+          }
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/PostBookFab.jsx
+++ b/src/components/PostBookFab.jsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { useTranslations } from "next-intl";
 import { usePathname, useRouter } from "@/i18n/navigation";
 import { isAuthenticated, getUserProfile } from "@/services/auth";
-import { openPostBookModal } from "@/lib/postBookModal";
+import { openPostChooser } from "@/lib/postBookModal";
 import { isProfileComplete } from "@/utils/profile";
 import Icon from "@/components/Icon";
 
@@ -52,9 +52,9 @@ const PostBookFab = () => {
         router.push("/account?complete=book");
         return;
       }
-      openPostBookModal();
+      openPostChooser();
     } catch {
-      openPostBookModal();
+      openPostChooser();
     } finally {
       setChecking(false);
     }

--- a/src/components/PostBookMount.jsx
+++ b/src/components/PostBookMount.jsx
@@ -2,39 +2,171 @@
 
 import React, { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
-import { POST_BOOK_MODAL_EVENT } from "@/lib/postBookModal";
+import { Dialog, DialogContent, Box, Stack, Typography, IconButton } from "@mui/material";
+import { useTranslations } from "next-intl";
+import Icon from "@/components/Icon";
+import {
+  POST_BOOK_MODAL_EVENT,
+  POST_BOOK_CHOOSER_EVENT,
+  openPostBookModal,
+  openPostBookFromShopModal,
+} from "@/lib/postBookModal";
+import {
+  POST_COLLECTION_MODAL_EVENT,
+  openPostCollectionModal,
+  openPostCollectionFromShopModal,
+} from "@/lib/postCollectionModal";
 
-// Lazy: the 1k-line modal stays off the wire until the user actually
-// taps the floating "post a book" button. After the first open we keep
-// the import resolved so subsequent opens are instant.
+// Both modals are heavy; keep them off the wire until first opened.
 const BookCreateModal = dynamic(() => import("./BookCreateModal"), {
   ssr: false,
   loading: () => null,
 });
+const CollectionCreateModal = dynamic(() => import("./CollectionCreateModal"), {
+  ssr: false,
+  loading: () => null,
+});
+
+// Single chooser → "single book" vs "collection". Lives here so every entry
+// point (FAB, shop "add") gets the same pre-question.
+function PostChooser({ open, onClose, onPick }) {
+  const t = useTranslations("CollectionCreateModal");
+  const options = [
+    {
+      key: "single",
+      icon: "ph-fill ph-book",
+      title: t("chooseSingle"),
+      desc: t("chooseSingleDesc"),
+    },
+    {
+      key: "collection",
+      icon: "ph-fill ph-stack",
+      title: t("chooseCollection"),
+      desc: t("chooseCollectionDesc"),
+    },
+  ];
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="xs"
+      PaperProps={{ sx: { borderRadius: 3 } }}
+    >
+      <DialogContent>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.5 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: 17 }}>{t("chooseTitle")}</Typography>
+          <IconButton size="small" onClick={onClose} aria-label="close">
+            <Icon className="ph ph-x" />
+          </IconButton>
+        </Stack>
+        <Stack spacing={1.25}>
+          {options.map((o) => (
+            <Box
+              key={o.key}
+              component="button"
+              type="button"
+              onClick={() => onPick(o.key)}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                width: "100%",
+                textAlign: "left",
+                p: 1.75,
+                borderRadius: 2.5,
+                border: "1px solid var(--border-subtle)",
+                bgcolor: "var(--surface-card)",
+                cursor: "pointer",
+                transition: "border-color 0.15s ease, background 0.15s ease",
+                "&:hover": {
+                  borderColor: "var(--main-600, #2e7d32)",
+                  bgcolor: "var(--main-50, #e6f4ea)",
+                },
+              }}
+            >
+              <Icon
+                className={o.icon}
+                style={{ fontSize: 26, color: "var(--main-600, #2e7d32)" }}
+                aria-hidden="true"
+              />
+              <Box sx={{ minWidth: 0 }}>
+                <Typography sx={{ fontWeight: 600 }}>{o.title}</Typography>
+                <Typography variant="caption" sx={{ color: "var(--text-muted)" }}>
+                  {o.desc}
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 export default function PostBookMount() {
-  const [open, setOpen] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  // Pre-selected shop when launched from a shop page (else null = personal).
-  const [initialShopId, setInitialShopId] = useState(null);
+  const [bookOpen, setBookOpen] = useState(false);
+  const [collectionOpen, setCollectionOpen] = useState(false);
+  const [bookMounted, setBookMounted] = useState(false);
+  const [collMounted, setCollMounted] = useState(false);
+  const [shopId, setShopId] = useState(null);
+  const [chooser, setChooser] = useState({ open: false, shopId: null });
 
   useEffect(() => {
-    const handler = (e) => {
-      setInitialShopId(e?.detail?.shopId ?? null);
-      setMounted(true);
-      setOpen(true);
+    const onBook = (e) => {
+      setShopId(e?.detail?.shopId ?? null);
+      setBookMounted(true);
+      setBookOpen(true);
     };
-    window.addEventListener(POST_BOOK_MODAL_EVENT, handler);
-    return () => window.removeEventListener(POST_BOOK_MODAL_EVENT, handler);
+    const onCollection = (e) => {
+      setShopId(e?.detail?.shopId ?? null);
+      setCollMounted(true);
+      setCollectionOpen(true);
+    };
+    const onChooser = (e) => setChooser({ open: true, shopId: e?.detail?.shopId ?? null });
+    window.addEventListener(POST_BOOK_MODAL_EVENT, onBook);
+    window.addEventListener(POST_COLLECTION_MODAL_EVENT, onCollection);
+    window.addEventListener(POST_BOOK_CHOOSER_EVENT, onChooser);
+    return () => {
+      window.removeEventListener(POST_BOOK_MODAL_EVENT, onBook);
+      window.removeEventListener(POST_COLLECTION_MODAL_EVENT, onCollection);
+      window.removeEventListener(POST_BOOK_CHOOSER_EVENT, onChooser);
+    };
   }, []);
 
-  if (!mounted) return null;
+  const handlePick = (kind) => {
+    const sid = chooser.shopId;
+    setChooser({ open: false, shopId: null });
+    if (kind === "single") {
+      sid ? openPostBookFromShopModal(sid) : openPostBookModal();
+    } else {
+      sid ? openPostCollectionFromShopModal(sid) : openPostCollectionModal();
+    }
+  };
+
   return (
-    <BookCreateModal
-      isOpen={open}
-      initialShopId={initialShopId}
-      onClose={() => setOpen(false)}
-      onSuccess={() => setOpen(false)}
-    />
+    <>
+      <PostChooser
+        open={chooser.open}
+        onClose={() => setChooser({ open: false, shopId: null })}
+        onPick={handlePick}
+      />
+      {bookMounted && (
+        <BookCreateModal
+          isOpen={bookOpen}
+          initialShopId={shopId}
+          onClose={() => setBookOpen(false)}
+          onSuccess={() => setBookOpen(false)}
+        />
+      )}
+      {collMounted && (
+        <CollectionCreateModal
+          isOpen={collectionOpen}
+          initialShopId={shopId}
+          onClose={() => setCollectionOpen(false)}
+          onSuccess={() => setCollectionOpen(false)}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/ShopDetailPage.jsx
+++ b/src/components/ShopDetailPage.jsx
@@ -18,7 +18,9 @@ import {
 import dynamic from "next/dynamic";
 import { getShopDetails } from "@/services/shop";
 import { getBooks } from "@/services/books";
-import { openPostBookFromShopModal } from "@/lib/postBookModal";
+import { getCollectionsByShop } from "@/services/collections";
+import CollectionRowGrid from "@/components/shared/CollectionRowGrid";
+import { openPostChooser } from "@/lib/postBookModal";
 import { getBookCategories, getBookSubcategories } from "@/services/categories";
 import BookRowGrid from "@/components/shared/BookRowGrid";
 import { openShareSheet } from "@/lib/shareSheet";
@@ -98,6 +100,7 @@ const localizeWorkingDays = (raw, tDays) => {
 
 const ShopDetailPage = ({ shopId }) => {
   const t = useTranslations("ShopDetailPage");
+  const tColl = useTranslations("CollectionCard");
   const tDays = useTranslations("Days");
   const tShare = useTranslations("Share");
   const tShopEdit = useTranslations("ShopEdit");
@@ -129,6 +132,7 @@ const ShopDetailPage = ({ shopId }) => {
 
   const [books, setBooks] = useState([]);
   const [booksLoading, setBooksLoading] = useState(true);
+  const [collections, setCollections] = useState([]);
 
   const [categories, setCategories] = useState([]);
   const [subcategories, setSubcategories] = useState([]);
@@ -219,6 +223,9 @@ const ShopDetailPage = ({ shopId }) => {
     if (categoryId) params.category = categoryId;
     if (subcategoryId) params.sub_category = subcategoryId;
     if (debouncedQuery) params.q = debouncedQuery;
+    // Hide books bundled into a collection from the standalone grid (they show
+    // as a collection card above). While searching, keep them findable.
+    else params.standalone = true;
 
     getBooks(params)
       .then((res) => {
@@ -232,6 +239,19 @@ const ShopDetailPage = ({ shopId }) => {
       alive = false;
     };
   }, [shopId, categoryId, subcategoryId, debouncedQuery]);
+
+  // ── Shop collections (bundles) ──────────────────────────────────────
+  useEffect(() => {
+    if (!shopId) return undefined;
+    let alive = true;
+    getCollectionsByShop(shopId, 12)
+      .then((res) => alive && setCollections(res.collections || []))
+      .catch(() => {})
+      .finally(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [shopId]);
 
   // ── Derived ──────────────────────────────────────────────────────────
   const star = useMemo(() => formatStar(shop?.star), [shop]);
@@ -535,7 +555,7 @@ const ShopDetailPage = ({ shopId }) => {
                   )}
                   {shop?.can_update && (
                     <Button
-                      onClick={() => openPostBookFromShopModal(shop.id)}
+                      onClick={() => openPostChooser(shop.id)}
                       variant="contained"
                       size="small"
                       startIcon={<Icon className="ph ph-plus" aria-hidden="true" />}
@@ -714,6 +734,15 @@ const ShopDetailPage = ({ shopId }) => {
             ))}
           </TextField>
         </Stack>
+
+        {collections.length > 0 && (
+          <Box sx={{ mb: 3 }}>
+            <Typography sx={{ fontSize: { xs: 16, md: 18 }, fontWeight: 700, mb: 1.5 }}>
+              {tColl("homeTitle")}
+            </Typography>
+            <CollectionRowGrid collections={collections} />
+          </Box>
+        )}
 
         <BookRowGrid
           books={books}

--- a/src/components/home/HomeBookList.jsx
+++ b/src/components/home/HomeBookList.jsx
@@ -30,7 +30,9 @@ const HomeBookList = ({ type, ownerType, titleKey, viewAllHref, limit = 6, initi
   useEffect(() => {
     if (hasInitial) return undefined;
     let alive = true;
-    const params = { is_active: true, limit };
+    // `standalone` hides books that live inside a collection — the bundle
+    // shows once as a collection card (see HomeCollectionsRow) instead.
+    const params = { is_active: true, standalone: true, limit };
     if (type) params.type = type;
     if (ownerType) params.owner_type = ownerType;
 

--- a/src/components/home/HomeCollectionsRow.jsx
+++ b/src/components/home/HomeCollectionsRow.jsx
@@ -1,0 +1,82 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Box, Stack, Typography } from "@mui/material";
+import { Link } from "@/i18n/navigation";
+import { getCollections } from "@/services/collections";
+import CollectionRowGrid from "@/components/shared/CollectionRowGrid";
+import Icon from "@/components/Icon";
+
+/**
+ * Home "Collections / bundles" row — same channel-header + responsive grid as
+ * HomeBookList, but for bundles. Self-fetches (collections are a small set)
+ * and hides when empty so data-light deploys stay tight.
+ */
+const HomeCollectionsRow = ({ limit = 6 }) => {
+  const t = useTranslations("CollectionCard");
+  const [collections, setCollections] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    getCollections({ is_active: true, limit })
+      .then((res) => {
+        if (alive) setCollections(res.collections || []);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [limit]);
+
+  if (!loading && collections.length === 0) return null;
+
+  return (
+    <Box component="section" sx={{ bgcolor: "var(--surface-page)", py: { xs: 2, md: 2.75 } }}>
+      <Box sx={{ maxWidth: 1240, mx: "auto", px: { xs: 2, md: 3 } }}>
+        <Stack direction="row" spacing={2} sx={{ alignItems: "center", mb: 1.5, minHeight: 32 }}>
+          <Typography
+            component="h2"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: { xs: 16, md: 18 },
+              fontWeight: 700,
+              color: "var(--text-primary)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {t("homeTitle")}
+          </Typography>
+          <Link
+            href="/collections"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              flexShrink: 0,
+              fontSize: 13,
+              fontWeight: 600,
+              color: "var(--main-600, hsl(148, 59%, 39%))",
+              textDecoration: "none",
+              padding: "6px 12px",
+              borderRadius: 999,
+            }}
+          >
+            {t("seeAll")}
+            <Icon className="ph ph-caret-right" aria-hidden="true" style={{ fontSize: 14 }} />
+          </Link>
+        </Stack>
+        <CollectionRowGrid collections={collections} loading={loading} skeletonCount={limit} />
+      </Box>
+    </Box>
+  );
+};
+
+export default HomeCollectionsRow;

--- a/src/components/shared/CollectionRow.jsx
+++ b/src/components/shared/CollectionRow.jsx
@@ -1,0 +1,235 @@
+"use client";
+
+import React from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { Box, Stack, Typography, Chip } from "@mui/material";
+import { Link } from "@/i18n/navigation";
+import { formatPrice } from "@/utils/formatPrice";
+import { resolveMediaUrl } from "@/utils/mediaUrl";
+import { bookOwnerLocation } from "@/utils/location";
+import Icon from "@/components/Icon";
+
+/**
+ * Compact bundle card for feed/browse grids — the collection sibling of
+ * BookChatRow, so books and bundles line up in the same responsive grid.
+ *
+ *   ┌────────────────────────────────────────┐
+ *   │ [montage]  Title (2 lines)   [📚 N]     │
+ *   │            Bundle price                  │
+ *   │            ̶O̶r̶i̶g̶i̶n̶a̶l̶  -20%   📍 Loc      │
+ *   └────────────────────────────────────────┘
+ *
+ * The thumbnail is a 2×2 montage of the first member covers with a "stack"
+ * badge so a bundle reads as a bundle at a glance.
+ */
+const MONTAGE_CELL = { width: "50%", height: "50%", position: "absolute", overflow: "hidden" };
+const CELL_POS = [
+  { top: 0, left: 0 },
+  { top: 0, right: 0 },
+  { bottom: 0, left: 0 },
+  { bottom: 0, right: 0 },
+];
+
+const CollectionRow = ({ collection }) => {
+  const t = useTranslations("CollectionCard");
+  const locale = useLocale();
+
+  const covers = (
+    collection.covers && collection.covers.length
+      ? collection.covers
+      : (collection.books || []).map((b) => b.picture).filter(Boolean)
+  ).slice(0, 4);
+  const count = collection.book_count ?? (collection.books || []).length;
+  const bundle = collection.bundle_price;
+  const original = collection.original_total;
+  const pct = collection.discount_percent;
+  const location = bookOwnerLocation(collection);
+
+  return (
+    <Link
+      href={`/collection/${collection.id}`}
+      style={{ textDecoration: "none", color: "inherit", display: "block", height: "100%" }}
+    >
+      <Stack
+        direction="row"
+        spacing={1.5}
+        sx={{
+          height: "100%",
+          alignItems: "center",
+          px: { xs: 1.5, md: 1.75 },
+          py: 1.5,
+          borderRadius: 2.5,
+          bgcolor: "var(--surface-card)",
+          border: "1px solid var(--border-subtle)",
+          boxShadow: "var(--shadow-card)",
+          transition: "transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease",
+          "&:hover": {
+            transform: "translateY(-2px)",
+            boxShadow: "var(--shadow-elevated)",
+            borderColor: "var(--main-600, hsl(148, 59%, 39%))",
+          },
+        }}
+      >
+        {/* Montage thumbnail */}
+        <Box
+          sx={{
+            position: "relative",
+            width: { xs: 60, md: 68 },
+            height: { xs: 60, md: 68 },
+            borderRadius: 2,
+            overflow: "hidden",
+            bgcolor: "var(--surface-muted)",
+            flexShrink: 0,
+          }}
+        >
+          {covers.length ? (
+            covers.map((src, i) => (
+              <Box key={i} sx={{ ...MONTAGE_CELL, ...CELL_POS[i] }}>
+                {/* eslint-disable-next-line @next/next/no-img-element -- tiny montage tile */}
+                <img
+                  src={resolveMediaUrl(src)}
+                  alt=""
+                  style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                  loading="lazy"
+                />
+              </Box>
+            ))
+          ) : (
+            <Icon
+              className="ph ph-stack"
+              style={{
+                fontSize: 24,
+                color: "var(--text-muted)",
+                position: "absolute",
+                inset: 0,
+                margin: "auto",
+              }}
+              aria-hidden="true"
+            />
+          )}
+          <Box
+            sx={{
+              position: "absolute",
+              bottom: 2,
+              left: 2,
+              width: 18,
+              height: 18,
+              borderRadius: 1,
+              bgcolor: "rgba(0,0,0,0.6)",
+              color: "#fff",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Icon className="ph-fill ph-stack" style={{ fontSize: 11 }} aria-hidden="true" />
+          </Box>
+        </Box>
+
+        {/* Text */}
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography
+            sx={{
+              fontWeight: 600,
+              fontSize: 14,
+              color: "var(--text-primary)",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+              lineHeight: 1.3,
+            }}
+          >
+            {collection.title || t("untitled")}
+          </Typography>
+          {bundle != null && bundle !== "" && (
+            <Typography
+              sx={{
+                mt: 0.25,
+                fontSize: 13.5,
+                fontWeight: 700,
+                color: "var(--main-600, hsl(148, 59%, 39%))",
+              }}
+            >
+              {formatPrice(bundle, locale)}
+            </Typography>
+          )}
+          <Stack
+            direction="row"
+            spacing={0.75}
+            sx={{ alignItems: "center", mt: 0.25, flexWrap: "wrap" }}
+          >
+            {pct ? (
+              <>
+                <Typography
+                  sx={{
+                    fontSize: 11.5,
+                    color: "var(--text-muted)",
+                    textDecoration: "line-through",
+                  }}
+                >
+                  {formatPrice(original, locale)}
+                </Typography>
+                <Chip
+                  size="small"
+                  label={t("discount", { percent: pct })}
+                  sx={{
+                    height: 18,
+                    fontSize: 10,
+                    fontWeight: 700,
+                    bgcolor: "var(--main-50, #e6f4ea)",
+                    color: "var(--main-600, #2e7d32)",
+                  }}
+                />
+              </>
+            ) : null}
+          </Stack>
+        </Box>
+
+        {/* Trailing: book count + location */}
+        <Stack sx={{ alignSelf: "stretch", alignItems: "flex-end", flexShrink: 0, gap: 0.75 }}>
+          <Chip
+            size="small"
+            icon={<Icon className="ph-fill ph-books" style={{ fontSize: 12 }} />}
+            label={t("itemCount", { count })}
+            sx={{
+              height: 22,
+              fontSize: 11,
+              fontWeight: 600,
+              bgcolor: "var(--surface-muted)",
+              color: "var(--text-secondary)",
+              "& .MuiChip-icon": { ml: 0.5 },
+            }}
+          />
+          {location && (
+            <Box
+              sx={{
+                mt: "auto",
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+                maxWidth: { xs: 120, md: 150 },
+                minWidth: 0,
+              }}
+            >
+              <Icon
+                className="ph-fill ph-map-pin"
+                style={{
+                  fontSize: 12,
+                  color: "var(--main-600, hsl(148, 59%, 39%))",
+                  flexShrink: 0,
+                }}
+                aria-hidden="true"
+              />
+              <Typography noWrap sx={{ fontSize: 11, lineHeight: 1.4, color: "var(--text-muted)" }}>
+                {location}
+              </Typography>
+            </Box>
+          )}
+        </Stack>
+      </Stack>
+    </Link>
+  );
+};
+
+export default CollectionRow;

--- a/src/components/shared/CollectionRowGrid.jsx
+++ b/src/components/shared/CollectionRowGrid.jsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+import { Box } from "@mui/material";
+import CollectionRow from "@/components/shared/CollectionRow";
+import BookRowSkeleton from "@/components/shared/BookRowSkeleton";
+
+/**
+ * Same responsive grid as BookRowGrid (xs 1 / sm 2 / lg 3) so bundles and
+ * single books break at identical points across feeds.
+ */
+const GRID_SX = {
+  display: "grid",
+  gridTemplateColumns: {
+    xs: "minmax(0, 1fr)",
+    sm: "repeat(2, minmax(0, 1fr))",
+    lg: "repeat(3, minmax(0, 1fr))",
+  },
+  gap: { xs: 1.25, md: 1.5 },
+};
+
+const CollectionRowGrid = ({
+  collections = [],
+  loading = false,
+  skeletonCount = 3,
+  emptyState = null,
+}) => {
+  if (loading) {
+    return (
+      <Box sx={GRID_SX}>
+        {Array.from({ length: skeletonCount }).map((_, i) => (
+          <BookRowSkeleton key={`coll-skel-${i}`} />
+        ))}
+      </Box>
+    );
+  }
+  if (!collections.length) return emptyState;
+  return (
+    <Box sx={GRID_SX}>
+      {collections.map((c) => (
+        <CollectionRow key={c.id} collection={c} />
+      ))}
+    </Box>
+  );
+};
+
+export default CollectionRowGrid;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -73,6 +73,18 @@ export const API_ENDPOINTS = {
       DELETE: "api/v1/book/comment",
     },
   },
+  // Book collections (bundles). The backend lives under the book app
+  // (/api/v1/book/collections/...). DETAIL is a prefix — callers append
+  // `/${id}/`; membership actions append `/${id}/books/...`.
+  COLLECTIONS: {
+    LIST: "api/v1/book/collections/list/",
+    DETAIL: "api/v1/book/collections", // append `/${id}/`
+    CREATE: "api/v1/book/collections/create/",
+    UPDATE: "api/v1/book/collections", // append `/${id}/` — PATCH
+    DELETE: "api/v1/book/collections", // append `/${id}/` — DELETE
+    ADD_BOOK: "api/v1/book/collections", // append `/${id}/books/add/`
+    BOOK: "api/v1/book/collections", // append `/${id}/books/${bookId}/` (DELETE) or `.../move/`
+  },
   SHOPS: {
     LIST: "api/v1/shop/list/",
     DETAIL: "api/v1/shop", // caller appends `/${id}/`

--- a/src/lib/http.js
+++ b/src/lib/http.js
@@ -44,6 +44,7 @@ const TTL_MAP = [
   ["/faqs", 24 * 60 * 60 * 1000], // 24 h
   ["/policies", 24 * 60 * 60 * 1000], // 24 h — admin-curated content
   ["/stories", 2 * 60 * 1000], // 2 min — frequent freshness, expires fast
+  ["/collections", 5 * 60 * 1000], // 5 min — bundles change less than feeds
   ["/categories", 60 * 60 * 1000], // 1 h
   ["/banners", 30 * 60 * 1000], // 30 min
   ["/books", 10 * 60 * 1000], // 10 min

--- a/src/lib/postBookModal.js
+++ b/src/lib/postBookModal.js
@@ -23,3 +23,17 @@ export function openPostBookFromShopModal(shopId) {
 }
 
 export const POST_BOOK_MODAL_EVENT = EVENT;
+
+// Pre-question: "sell a single book or build a collection?". The entry points
+// (FAB, shop "add" button) open this chooser, which then dispatches the book
+// or collection modal event. Carries an optional shopId for shop context.
+const CHOOSER_EVENT = "post-book-chooser:open";
+
+export function openPostChooser(shopId = null) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(CHOOSER_EVENT, { detail: { shopId: shopId ? String(shopId) : null } }),
+  );
+}
+
+export const POST_BOOK_CHOOSER_EVENT = CHOOSER_EVENT;

--- a/src/lib/postCollectionModal.js
+++ b/src/lib/postCollectionModal.js
@@ -1,0 +1,18 @@
+/**
+ * Event bus for opening the CollectionCreateModal (bundle wizard) from
+ * anywhere — mirror of postBookModal.js.
+ */
+const EVENT = "post-collection-modal:open";
+
+export function openPostCollectionModal() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(EVENT, { detail: { shopId: null } }));
+}
+
+/** Open the bundle wizard pre-attributed to a shop the user owns/staffs. */
+export function openPostCollectionFromShopModal(shopId) {
+  if (typeof window === "undefined" || !shopId) return;
+  window.dispatchEvent(new CustomEvent(EVENT, { detail: { shopId: String(shopId) } }));
+}
+
+export const POST_COLLECTION_MODAL_EVENT = EVENT;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -96,7 +96,9 @@
     "cancel": "Cancel",
     "save": "Save",
     "close": "Close",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "back": "Back",
+    "delete": "Delete"
   },
   "Breadcrumb": {
     "home": "Home",
@@ -1071,5 +1073,58 @@
       "topRegions": "Top regions",
       "bannedRatio": "Banned ratio"
     }
+  },
+  "CollectionCreateModal": {
+    "title": "Create a collection",
+    "priceTitle": "Bundle price",
+    "pickTitle": "Pick books",
+    "listHint": "Add at least 2 books to the collection.",
+    "empty": "No books added yet",
+    "addNew": "New book",
+    "addExisting": "Existing book",
+    "continue": "Continue",
+    "needTwo": "At least 2 books are required.",
+    "sumLabel": "Sum of individual prices",
+    "sumHint": "Price of {count} books",
+    "bundlePrice": "Bundle price (total)",
+    "cheaperHint": "Best kept cheaper than the sum of individual prices.",
+    "tooHigh": "Bundle price must not exceed the sum of individual prices.",
+    "savings": "You save {amount}",
+    "create": "Create collection",
+    "created": "Collection created",
+    "error": "Something went wrong",
+    "noExisting": "No free books to add",
+    "addSelected": "Add selected",
+    "chooseTitle": "What are you posting?",
+    "chooseSingle": "A single book",
+    "chooseSingleDesc": "Sell one book on its own",
+    "chooseCollection": "A collection",
+    "chooseCollectionDesc": "Sell several books together"
+  },
+  "CollectionCard": {
+    "untitled": "Collection",
+    "discount": "{percent}% off",
+    "itemCount": "{count} books",
+    "homeTitle": "Book collections",
+    "seeAll": "See all",
+    "none": "No collections"
+  },
+  "CollectionDetails": {
+    "notFound": "Collection not found",
+    "untitled": "Collection",
+    "bundleBadge": "Bundle of {count} books",
+    "savePercent": "save {percent}%",
+    "manage": "Manage",
+    "doneManaging": "Done",
+    "deleteCollection": "Delete collection",
+    "deleteConfirm": "Delete this collection? The books are not deleted, only the bundle.",
+    "deleted": "Collection deleted",
+    "memberBooks": "Books in this collection ({count})",
+    "moveBook": "Move to another collection",
+    "detachBook": "Detach from collection",
+    "detached": "Book detached",
+    "moved": "Book moved",
+    "actionFailed": "Action failed",
+    "noTargets": "No other collections"
   }
 }

--- a/src/messages/kaa.json
+++ b/src/messages/kaa.json
@@ -96,7 +96,9 @@
     "cancel": "Biykarlaw",
     "save": "Saqlaw",
     "close": "Jabıw",
-    "loading": "Júklenbekte..."
+    "loading": "Júklenbekte...",
+    "back": "Artqa",
+    "delete": "Óshiriw"
   },
   "Breadcrumb": {
     "home": "Bas bet",
@@ -1071,5 +1073,58 @@
       "topRegions": "Top hududlar",
       "bannedRatio": "Bloklangan ulush"
     }
+  },
+  "CollectionCreateModal": {
+    "title": "Toplam dúziw",
+    "priceTitle": "Toplam bahası",
+    "pickTitle": "Kitap tańlań",
+    "listHint": "Toplamǵa keminde 2 kitap qosıń.",
+    "empty": "Ále kitap qosılmaǵan",
+    "addNew": "Jańa kitap",
+    "addExisting": "Bar kitap",
+    "continue": "Dawam etiw",
+    "needTwo": "Keminde 2 kitap kerek.",
+    "sumLabel": "Ayrım bahalar jıyındısı",
+    "sumHint": "{count} kitaptıń bahası",
+    "bundlePrice": "Toplam bahası (ulıwma)",
+    "cheaperHint": "Ayrım bahalar jıyındısınan arzan bolǵanı maqul.",
+    "tooHigh": "Toplam bahası ayrım bahalar jıyındısınan aspawı kerek.",
+    "savings": "{amount} úneminiz",
+    "create": "Toplam jaratıw",
+    "created": "Toplam jaratıldı",
+    "error": "Qátelik júz berdi",
+    "noExisting": "Qosıw ushın bos kitap joq",
+    "addSelected": "Tańlanǵanlardı qosıw",
+    "chooseTitle": "Nelerdi jaylaysız?",
+    "chooseSingle": "Bir kitap",
+    "chooseSingleDesc": "Bir kitaptı ayrım satıw",
+    "chooseCollection": "Toplam",
+    "chooseCollectionDesc": "Bir neshe kitaptı birge satıw"
+  },
+  "CollectionCard": {
+    "untitled": "Toplam",
+    "discount": "{percent}% jeńillik",
+    "itemCount": "{count} dana",
+    "homeTitle": "Kitap toplamları",
+    "seeAll": "Hámmesin kóriw",
+    "none": "Toplamlar joq"
+  },
+  "CollectionDetails": {
+    "notFound": "Toplam tabılmadı",
+    "untitled": "Toplam",
+    "bundleBadge": "{count} kitap toplamı",
+    "savePercent": "{percent}% úneminiz",
+    "manage": "Basqarıw",
+    "doneManaging": "Tayyar",
+    "deleteCollection": "Toplamdı óshiriw",
+    "deleteConfirm": "Toplamdı óshiresizbe? Kitaplar óshpeydi, tek toplam.",
+    "deleted": "Toplam óshirildi",
+    "memberBooks": "Toplamdaǵı kitaplar ({count})",
+    "moveBook": "Basqa toplamǵa kóshiriw",
+    "detachBook": "Toplamnan ajratıw",
+    "detached": "Kitap ajratıldı",
+    "moved": "Kitap kóshirildi",
+    "actionFailed": "Ámel orınlanbadı",
+    "noTargets": "Basqa toplam joq"
   }
 }

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -96,7 +96,9 @@
     "cancel": "Отмена",
     "save": "Сохранить",
     "close": "Закрыть",
-    "loading": "Загрузка..."
+    "loading": "Загрузка...",
+    "back": "Назад",
+    "delete": "Удалить"
   },
   "Breadcrumb": {
     "home": "Главная",
@@ -1071,5 +1073,58 @@
       "topRegions": "Топ регионов",
       "bannedRatio": "Доля заблокированных"
     }
+  },
+  "CollectionCreateModal": {
+    "title": "Создать набор",
+    "priceTitle": "Цена набора",
+    "pickTitle": "Выберите книги",
+    "listHint": "Добавьте в набор минимум 2 книги.",
+    "empty": "Книги ещё не добавлены",
+    "addNew": "Новая книга",
+    "addExisting": "Существующая",
+    "continue": "Продолжить",
+    "needTwo": "Нужно минимум 2 книги.",
+    "sumLabel": "Сумма отдельных цен",
+    "sumHint": "Цена {count} книг",
+    "bundlePrice": "Цена набора (общая)",
+    "cheaperHint": "Лучше дешевле суммы отдельных цен.",
+    "tooHigh": "Цена набора не должна превышать сумму отдельных цен.",
+    "savings": "Экономия {amount}",
+    "create": "Создать набор",
+    "created": "Набор создан",
+    "error": "Произошла ошибка",
+    "noExisting": "Нет свободных книг",
+    "addSelected": "Добавить выбранные",
+    "chooseTitle": "Что разместить?",
+    "chooseSingle": "Одна книга",
+    "chooseSingleDesc": "Продать одну книгу отдельно",
+    "chooseCollection": "Набор",
+    "chooseCollectionDesc": "Продать несколько книг вместе"
+  },
+  "CollectionCard": {
+    "untitled": "Набор",
+    "discount": "скидка {percent}%",
+    "itemCount": "{count} шт.",
+    "homeTitle": "Наборы книг",
+    "seeAll": "Смотреть все",
+    "none": "Наборов нет"
+  },
+  "CollectionDetails": {
+    "notFound": "Набор не найден",
+    "untitled": "Набор",
+    "bundleBadge": "Набор из {count} книг",
+    "savePercent": "экономия {percent}%",
+    "manage": "Управление",
+    "doneManaging": "Готово",
+    "deleteCollection": "Удалить набор",
+    "deleteConfirm": "Удалить набор? Книги не удалятся, только набор.",
+    "deleted": "Набор удалён",
+    "memberBooks": "Книги в наборе ({count})",
+    "moveBook": "Переместить в другой набор",
+    "detachBook": "Убрать из набора",
+    "detached": "Книга убрана",
+    "moved": "Книга перемещена",
+    "actionFailed": "Не удалось выполнить",
+    "noTargets": "Других наборов нет"
   }
 }

--- a/src/messages/uz.json
+++ b/src/messages/uz.json
@@ -96,7 +96,9 @@
     "cancel": "Bekor qilish",
     "save": "Saqlash",
     "close": "Yopish",
-    "loading": "Yuklanmoqda..."
+    "loading": "Yuklanmoqda...",
+    "back": "Orqaga",
+    "delete": "O'chirish"
   },
   "Breadcrumb": {
     "home": "Bosh sahifa",
@@ -1071,5 +1073,58 @@
       "topRegions": "Top hududlar",
       "bannedRatio": "Bloklangan ulush"
     }
+  },
+  "CollectionCreateModal": {
+    "title": "To'plam tuzish",
+    "priceTitle": "To'plam narxi",
+    "pickTitle": "Kitob tanlang",
+    "listHint": "To'plamga kamida 2 ta kitob qo'shing.",
+    "empty": "Hali kitob qo'shilmagan",
+    "addNew": "Yangi kitob",
+    "addExisting": "Mavjud kitob",
+    "continue": "Davom etish",
+    "needTwo": "Kamida 2 ta kitob kerak.",
+    "sumLabel": "Alohida narxlar yig'indisi",
+    "sumHint": "{count} ta kitobning narxi",
+    "bundlePrice": "To'plam narxi (umumiy)",
+    "cheaperHint": "Alohida narxlar yig'indisidan arzon bo'lgani ma'qul.",
+    "tooHigh": "To'plam narxi alohida narxlar yig'indisidan oshmasligi kerak.",
+    "savings": "{amount} tejaysiz",
+    "create": "To'plam yaratish",
+    "created": "To'plam yaratildi",
+    "error": "Xatolik yuz berdi",
+    "noExisting": "Qo'shish uchun bo'sh kitob yo'q",
+    "addSelected": "Tanlanganlarni qo'shish",
+    "chooseTitle": "Nima joylaysiz?",
+    "chooseSingle": "Bitta kitob",
+    "chooseSingleDesc": "Bitta kitobni alohida soting",
+    "chooseCollection": "To'plam",
+    "chooseCollectionDesc": "Bir nechta kitobni birga soting"
+  },
+  "CollectionCard": {
+    "untitled": "To'plam",
+    "discount": "{percent}% chegirma",
+    "itemCount": "{count} ta",
+    "homeTitle": "Kitob to'plamlari",
+    "seeAll": "Hammasini ko'rish",
+    "none": "To'plamlar yo'q"
+  },
+  "CollectionDetails": {
+    "notFound": "To'plam topilmadi",
+    "untitled": "To'plam",
+    "bundleBadge": "{count} ta kitob to'plami",
+    "savePercent": "{percent}% tejaysiz",
+    "manage": "Boshqarish",
+    "doneManaging": "Tayyor",
+    "deleteCollection": "To'plamni o'chirish",
+    "deleteConfirm": "To'plamni o'chirasizmi? Kitoblar o'chmaydi, faqat to'plam.",
+    "deleted": "To'plam o'chirildi",
+    "memberBooks": "To'plamdagi kitoblar ({count})",
+    "moveBook": "Boshqa to'plamga ko'chirish",
+    "detachBook": "To'plamdan ajratish",
+    "detached": "Kitob ajratildi",
+    "moved": "Kitob ko'chirildi",
+    "actionFailed": "Amal bajarilmadi",
+    "noTargets": "Boshqa to'plam yo'q"
   }
 }

--- a/src/services/collections.js
+++ b/src/services/collections.js
@@ -1,0 +1,101 @@
+import http, { clearHttpCache } from "@/lib/http";
+import { API_ENDPOINTS } from "@/config";
+import { normalizeListResponse, normalizeItem } from "@/utils/normalizeResponse";
+import { withIdempotency } from "@/lib/idempotency";
+
+/**
+ * Collection writes can change which books are "bundled" (and thus hidden from
+ * the standalone feed), so drop both collection AND book caches.
+ */
+function invalidateCollectionCaches() {
+  try {
+    clearHttpCache("/collections");
+    clearHttpCache("/book/");
+  } catch {
+    /* best effort */
+  }
+}
+
+export async function getCollections(params = {}) {
+  const clean = Object.fromEntries(
+    Object.entries(params).filter(([, v]) => v !== "" && v !== null && v !== undefined),
+  );
+  const { data } = await http.get(API_ENDPOINTS.COLLECTIONS.LIST, { params: clean });
+  const { result: collections, count, next, previous, raw } = normalizeListResponse(data);
+  return { collections, count, next, previous, raw };
+}
+
+export async function getCollectionsByShop(shopId, limit = 12) {
+  return getCollections({ shop: shopId, is_active: true, limit });
+}
+
+export async function getCollectionsByUser(userId, limit = 12) {
+  return getCollections({ posted_by: userId, owner_type: "user", is_active: true, limit });
+}
+
+export async function getHomePageCollections(limit = 8) {
+  return getCollections({ for_home_page: true, is_active: true, limit });
+}
+
+export async function searchCollections(query, params = {}) {
+  return getCollections({ q: query, ...params });
+}
+
+export async function getCollectionById(id) {
+  const { data } = await http.get(`${API_ENDPOINTS.COLLECTIONS.DETAIL}/${id}/`);
+  return { collection: normalizeItem(data) };
+}
+
+export async function createCollection({ book_ids, bundle_price, shop }) {
+  const payload = { book_ids };
+  if (bundle_price !== undefined && bundle_price !== null && bundle_price !== "")
+    payload.bundle_price = bundle_price;
+  if (shop) payload.shop = Number(shop);
+  const { data } = await http.post(API_ENDPOINTS.COLLECTIONS.CREATE, payload, withIdempotency());
+  invalidateCollectionCaches();
+  return { collection: normalizeItem(data), success: data?.success === true, raw: data };
+}
+
+export async function patchCollection(id, body) {
+  const { data } = await http.patch(
+    `${API_ENDPOINTS.COLLECTIONS.UPDATE}/${id}/`,
+    body,
+    withIdempotency(),
+  );
+  invalidateCollectionCaches();
+  return { collection: normalizeItem(data), success: data?.success === true, raw: data };
+}
+
+export async function deleteCollection(id) {
+  const { data } = await http.delete(`${API_ENDPOINTS.COLLECTIONS.DELETE}/${id}/`, {
+    skipAuthRefresh: false,
+  });
+  invalidateCollectionCaches();
+  return { success: data?.success === true, raw: data };
+}
+
+export async function addBookToCollection(id, bookId) {
+  const { data } = await http.post(
+    `${API_ENDPOINTS.COLLECTIONS.ADD_BOOK}/${id}/books/add/`,
+    { book_id: bookId },
+    withIdempotency(),
+  );
+  invalidateCollectionCaches();
+  return { collection: normalizeItem(data), success: data?.success === true, raw: data };
+}
+
+export async function detachBookFromCollection(id, bookId) {
+  const { data } = await http.delete(`${API_ENDPOINTS.COLLECTIONS.BOOK}/${id}/books/${bookId}/`);
+  invalidateCollectionCaches();
+  return { collection: normalizeItem(data), success: data?.success === true, raw: data };
+}
+
+export async function moveBookToCollection(id, bookId, targetCollectionId) {
+  const { data } = await http.post(
+    `${API_ENDPOINTS.COLLECTIONS.BOOK}/${id}/books/${bookId}/move/`,
+    { target_collection_id: targetCollectionId },
+    withIdempotency(),
+  );
+  invalidateCollectionCaches();
+  return { collection: normalizeItem(data), success: data?.success === true, raw: data };
+}

--- a/tests/unit/collections.service.test.js
+++ b/tests/unit/collections.service.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { get, post, del, patch } = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  del: vi.fn(),
+  patch: vi.fn(),
+}));
+vi.mock("@/lib/http", () => ({
+  default: { get, post, delete: del, patch },
+  clearHttpCache: vi.fn(),
+}));
+vi.mock("@/lib/idempotency", () => ({ withIdempotency: (c = {}) => c }));
+
+import { getCollections, createCollection, detachBookFromCollection } from "@/services/collections";
+import { API_ENDPOINTS } from "@/config";
+
+beforeEach(() => {
+  get.mockReset();
+  post.mockReset();
+  del.mockReset();
+  patch.mockReset();
+});
+
+describe("collections service", () => {
+  it("getCollections normalizes the paginated envelope + drops empty params", async () => {
+    get.mockResolvedValue({
+      data: { result: { count: 2, results: [{ id: 1 }, { id: 2 }] }, success: true },
+    });
+    const out = await getCollections({ is_active: true, q: "", shop: 5 });
+    expect(get).toHaveBeenCalledWith(
+      API_ENDPOINTS.COLLECTIONS.LIST,
+      expect.objectContaining({ params: { is_active: true, shop: 5 } }),
+    );
+    expect(out.collections).toHaveLength(2);
+    expect(out.count).toBe(2);
+  });
+
+  it("createCollection posts book_ids + bundle_price and unwraps the result", async () => {
+    post.mockResolvedValue({ data: { result: { id: 9, title: "A, B" }, success: true } });
+    const out = await createCollection({ book_ids: [1, 2], bundle_price: "300" });
+    const [url, body] = post.mock.calls[0];
+    expect(url).toBe(API_ENDPOINTS.COLLECTIONS.CREATE);
+    expect(body).toEqual({ book_ids: [1, 2], bundle_price: "300" });
+    expect(out.collection.id).toBe(9);
+  });
+
+  it("detach hits the per-book DELETE route", async () => {
+    del.mockResolvedValue({ data: { result: { id: 9 }, success: true } });
+    await detachBookFromCollection(9, 4);
+    expect(del).toHaveBeenCalledWith(`${API_ENDPOINTS.COLLECTIONS.BOOK}/9/books/4/`);
+  });
+});


### PR DESCRIPTION
Frontend for the Book Collection / bundle feature. Pairs with backend menOtabek/kitobzor#103. **Additive** — single-book flows unchanged (`BookCreateModal` gains only an optional `lockShop` prop).

## Create
- A pre-question chooser (**single book** vs **collection**) behind the FAB and the shop "add" button.
- **CollectionCreateModal** wizard: add NEW books via the reused `BookCreateModal` (`lockShop` keeps all books under one owner), or pick already-posted standalone books; then a **bundle-price** step showing Σ individual prices, a "cheaper is better" hint, and a hard cap (can't exceed Σ).

## Display ("only the bundle shows in feeds")
- `CollectionRow` + `CollectionRowGrid` (montage thumb, bundle price, struck original, % off, book-count).
- Home gets a **Book collections** row; home + shop book feeds request `standalone=true` so bundled books are hidden (shown once as a card). ShopDetailPage shows the shop's collections above its books.

## Detail & management
- **/collection/[id]** — hero (montage, bundle vs original price, savings), seller link, member-book list; owner can **detach / move / delete**.
- **/collections** hub (see-all target).

## i18n / tests
New namespaces `CollectionCreateModal` / `CollectionCard` / `CollectionDetails` across all 4 locales (i18n:check **911**). `collections.service.test.js` (3) → **175** vitest pass. Lint + `next build` green.

## Deploy
Frontend image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)