### PR TITLE
Merge feat/book-collections into dev (book-card list consistency fix)

### DIFF
--- a/src/components/ShopDetailPage.jsx
+++ b/src/components/ShopDetailPage.jsx
@@ -748,7 +748,11 @@ const ShopDetailPage = ({ shopId }) => {
           books={books}
           loading={booksLoading}
           skeletonCount={5}
-          showTypeBadge={false}
+          // A shop sells mixed types (sell/rent/gift/exchange) with no
+          // per-type header, so show the type chip — same as the community
+          // feed and the book-detail "more from seller" list. Plain sells
+          // with a price suppress the redundant chip inside BookChatRow.
+          showTypeBadge={true}
           emptyState={
             <Stack
               spacing={1}

--- a/src/components/shared/BookChatRow.jsx
+++ b/src/components/shared/BookChatRow.jsx
@@ -14,14 +14,16 @@ import Icon from "@/components/Icon";
  * Compact horizontal book card used in the feed/browse listings:
  *
  *   ┌──────────────────────────────────────┐
- *   │ [thumb 64]  Title (bold)     [badge]  │
+ *   │ [thumb 64]  Title (bold)              │
  *   │             Author                    │
- *   │             Price        📍 Location  │
+ *   │             Price  [badge]            │
+ *   │             📍 Location               │
  *   └──────────────────────────────────────┘
  *
- * The trailing column is vertically split: type badge pinned top-right,
- * the poster's "Region, District" pinned bottom-right (hidden when the
- * payload carries no location — e.g. shop books).
+ * Everything lives in ONE content column to the right of the thumb, so the
+ * title always gets the full remaining width at any container size. (A former
+ * fixed-width trailing column for badge+location starved the title to 0px in
+ * narrow grids — shop detail, book-detail "more from seller" — hiding it.)
  *
  * It is a *self-contained card* (border + shadow + hover lift, mirroring
  * ShopCard) so it can sit in a responsive grid — `BookRowGrid` lays these out
@@ -29,9 +31,10 @@ import Icon from "@/components/Icon";
  * desktop layout stops wasting horizontal space. `height: 100%` keeps every
  * card in a grid row the same height.
  *
- * Reused by `HomeBookList`, `CommunityBooksPage`, and `ShopDetailPage`.
- * When `showTypeBadge` is true the trailing badge is rendered; pass false in
- * single-type listings where the badge would be redundant.
+ * Reused by `HomeBookList`, `CommunityBooksPage`, `ShopDetailPage` and
+ * `MoreFromSellerSection`. The type is shown exactly one way — the colored
+ * chip — in every mixed listing (`showTypeBadge`); single-type sections pass
+ * `showTypeBadge=false` because their header already states the type.
  */
 const BookChatRow = ({ book, showTypeBadge = true }) => {
   const tType = useTranslations("BookTypeChips");
@@ -40,16 +43,22 @@ const BookChatRow = ({ book, showTypeBadge = true }) => {
   const typeKey = (book.type || "").toLowerCase();
   const badge = bookTypeVisual(typeKey);
 
-  // Monetary types (sell/rent) show the price on its OWN line under the author,
-  // so a long author name can never push it out of view. Non-monetary types
-  // (gift/exchange) carry no price — the trailing badge conveys the type; we
-  // only fall back to a text label for them when the badge is hidden.
+  // Monetary types (sell/rent) show the price on its own line under the author,
+  // so a long author name can never push it out of view.
   const isMonetary = typeKey === "seller" || typeKey === "rent";
   const price = book.discount_price || book.price;
   const priceLabel = isMonetary && price ? formatPrice(price, locale) : null;
-  const typeLabel = !isMonetary && badge ? tType(bookTypeI18nKey(typeKey)) : null;
   const location = bookOwnerLocation(book);
-  const hasTrailing = Boolean((showTypeBadge && badge) || location);
+
+  // The type is shown ONE way everywhere — the colored chip — for a consistent
+  // visual language across the home feed, shop detail, community and the
+  // book-detail "more from seller" list (there is no muted-text variant). The
+  // chip is rendered in mixed listings (showTypeBadge), EXCEPT for a plain
+  // "sell" book that already shows a price — there "Sotiladigan" just echoes
+  // the price (redundant noise). Rent keeps its chip so "Ijaraga + price" stays
+  // distinguishable from an outright sale. Single-type sections pass
+  // showTypeBadge=false: their header already states the type, so no chip.
+  const showTypeChip = showTypeBadge && badge && !(typeKey === "seller" && priceLabel);
 
   return (
     <Link
@@ -61,7 +70,7 @@ const BookChatRow = ({ book, showTypeBadge = true }) => {
         spacing={1.5}
         sx={{
           height: "100%",
-          alignItems: "center",
+          alignItems: "flex-start",
           px: { xs: 1.5, md: 1.75 },
           py: 1.5,
           borderRadius: 2.5,
@@ -105,16 +114,20 @@ const BookChatRow = ({ book, showTypeBadge = true }) => {
             />
           )}
         </Box>
-        <Box sx={{ flex: 1, minWidth: 0 }}>
+        {/* Single content column. Everything (title, author, price, type
+            badge, location) lives here so the title always gets the full
+            remaining width minus the thumb — at ANY container width. The
+            previous fixed-width trailing column (badge + location pinned
+            right) starved this column to 0px in narrow grids (shop detail,
+            book-detail "more from seller"), hiding the title entirely. */}
+        <Stack sx={{ flex: 1, minWidth: 0, gap: 0.25 }}>
           <Typography
             sx={{
               fontWeight: 600,
               fontSize: 14,
               color: "var(--text-primary)",
-              // Wrap to 2 lines instead of a single-line cut: in narrow grid
-              // columns (e.g. the book-detail "more from seller" list) a
-              // nowrap ellipsis chopped most titles. Two lines show the full
-              // name for realistic lengths, matching the roomier home feed.
+              // Two lines so realistic titles show in full without a
+              // single-line chop; matches the roomy home feed.
               display: "-webkit-box",
               WebkitLineClamp: 2,
               WebkitBoxOrient: "vertical",
@@ -124,96 +137,66 @@ const BookChatRow = ({ book, showTypeBadge = true }) => {
           >
             {book.name || "—"}
           </Typography>
+
           {book.author && (
-            <Typography
-              sx={{
-                fontSize: 12,
-                color: "var(--text-muted)",
-                display: "-webkit-box",
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: "vertical",
-                overflow: "hidden",
-              }}
-            >
+            // One line (ellipsis): author names rarely need two, and the
+            // extra reserved line made cards feel bulky ("qalin").
+            <Typography noWrap sx={{ fontSize: 12, color: "var(--text-muted)" }}>
               {book.author}
             </Typography>
           )}
-          {priceLabel ? (
-            <Typography
-              sx={{
-                mt: 0.25,
-                fontSize: 13,
-                fontWeight: 700,
-                color: "var(--main-600, hsl(148, 59%, 39%))",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
+
+          {(priceLabel || showTypeChip) && (
+            <Stack
+              direction="row"
+              spacing={0.75}
+              sx={{ alignItems: "center", flexWrap: "wrap", mt: 0.25 }}
             >
-              {priceLabel}
-            </Typography>
-          ) : (
-            !showTypeBadge &&
-            typeLabel && (
-              <Typography sx={{ mt: 0.25, fontSize: 12, color: "var(--text-muted)" }}>
-                {typeLabel}
-              </Typography>
-            )
-          )}
-        </Box>
-        {hasTrailing && (
-          <Stack
-            sx={{
-              alignSelf: "stretch",
-              alignItems: "flex-end",
-              flexShrink: 0,
-              gap: 0.75,
-            }}
-          >
-            {showTypeBadge && badge && (
-              <Chip
-                size="small"
-                label={tType(bookTypeI18nKey(typeKey))}
-                sx={{
-                  height: 22,
-                  fontSize: 11,
-                  fontWeight: 600,
-                  bgcolor: badge.bg,
-                  color: badge.color,
-                  border: "none",
-                }}
-              />
-            )}
-            {location && (
-              <Box
-                sx={{
-                  mt: "auto",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 0.5,
-                  maxWidth: { xs: 124, md: 156 },
-                  minWidth: 0,
-                }}
-              >
-                <Icon
-                  className="ph-fill ph-map-pin"
-                  style={{
-                    fontSize: 13,
-                    color: "var(--main-600, hsl(148, 59%, 39%))",
-                    flexShrink: 0,
-                  }}
-                  aria-hidden="true"
-                />
+              {priceLabel && (
                 <Typography
-                  noWrap
-                  sx={{ fontSize: 11, lineHeight: 1.4, color: "var(--text-muted)" }}
+                  sx={{
+                    fontSize: 13,
+                    fontWeight: 700,
+                    color: "var(--main-600, hsl(148, 59%, 39%))",
+                  }}
                 >
-                  {location}
+                  {priceLabel}
                 </Typography>
-              </Box>
-            )}
-          </Stack>
-        )}
+              )}
+              {showTypeChip && (
+                <Chip
+                  size="small"
+                  label={tType(bookTypeI18nKey(typeKey))}
+                  sx={{
+                    height: 20,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    bgcolor: badge.bg,
+                    color: badge.color,
+                    border: "none",
+                  }}
+                />
+              )}
+            </Stack>
+          )}
+
+          {location && (
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0, mt: 0.25 }}>
+              <Icon
+                className="ph-fill ph-map-pin"
+                style={{
+                  fontSize: 13,
+                  color: "var(--main-600, hsl(148, 59%, 39%))",
+                  flexShrink: 0,
+                }}
+                aria-hidden="true"
+              />
+              <Typography noWrap sx={{ fontSize: 11, lineHeight: 1.4, color: "var(--text-muted)" }}>
+                {location}
+              </Typography>
+            </Box>
+          )}
+        </Stack>
       </Stack>
     </Link>
   );

--- a/src/components/shared/BookRowSkeleton.jsx
+++ b/src/components/shared/BookRowSkeleton.jsx
@@ -2,10 +2,10 @@ import React from "react";
 import { Box, Stack } from "@mui/material";
 
 /**
- * Loading placeholder matching the `BookChatRow` card (same chrome: thumb +
- * two text lines inside a bordered card) so the feed/browse grids keep a
- * stable cell height while data loads. Shimmer comes from the shared
- * `.kz-skel` class.
+ * Loading placeholder matching the `BookChatRow` card. Mirrors the live card's
+ * chrome AND its line count (title, author, price, location) + top alignment,
+ * so the cell doesn't jump or resize when real data swaps in. Shimmer comes
+ * from the shared `.kz-skel` class.
  */
 const BookRowSkeleton = () => (
   <Stack
@@ -13,9 +13,9 @@ const BookRowSkeleton = () => (
     spacing={1.5}
     sx={{
       height: "100%",
-      alignItems: "center",
+      alignItems: "flex-start",
       px: { xs: 1.5, md: 1.75 },
-      py: 1.25,
+      py: 1.5,
       borderRadius: 2.5,
       bgcolor: "var(--surface-card)",
       border: "1px solid var(--border-subtle)",
@@ -24,11 +24,13 @@ const BookRowSkeleton = () => (
   >
     <Box
       className="kz-skel"
-      sx={{ width: { xs: 52, md: 60 }, height: { xs: 52, md: 60 }, borderRadius: 2, flexShrink: 0 }}
+      sx={{ width: { xs: 56, md: 64 }, height: { xs: 56, md: 64 }, borderRadius: 2, flexShrink: 0 }}
     />
     <Box sx={{ flex: 1, minWidth: 0 }}>
-      <Box className="kz-skel" sx={{ height: 13, width: "55%", mb: 0.75, borderRadius: 1 }} />
-      <Box className="kz-skel" sx={{ height: 11, width: "38%", borderRadius: 1 }} />
+      <Box className="kz-skel" sx={{ height: 13, width: "80%", mb: 0.75, borderRadius: 1 }} />
+      <Box className="kz-skel" sx={{ height: 11, width: "45%", mb: 0.75, borderRadius: 1 }} />
+      <Box className="kz-skel" sx={{ height: 12, width: "30%", mb: 0.75, borderRadius: 1 }} />
+      <Box className="kz-skel" sx={{ height: 11, width: "55%", borderRadius: 1 }} />
     </Box>
   </Stack>
 );

--- a/src/utils/formatPrice.js
+++ b/src/utils/formatPrice.js
@@ -10,15 +10,19 @@ function toNumber(value) {
   return isNaN(n) ? null : n;
 }
 
-// Group thousands with a comma using a pure string operation. We deliberately
-// do NOT use `Intl.NumberFormat` with a locale like `uz-UZ`: Node's server ICU
-// and the browser ICU emit different group separators for that locale (space
-// vs comma), so every price text differed between SSR and client and triggered
-// a React hydration mismatch. Manual grouping is identical everywhere.
+// Group thousands with a (non-breaking) space using a pure string operation —
+// the Uzbek convention is "160 000", not "160,000". We deliberately do NOT use
+// `Intl.NumberFormat` with a locale like `uz-UZ`: Node's server ICU and the
+// browser ICU emit different group separators for that locale, so every price
+// text differed between SSR and client and triggered a React hydration
+// mismatch. A literal separator constant is identical everywhere, so it stays
+// hydration-safe. The separator is a NBSP ( ) so a number never wraps
+// across lines mid-group ("160\n000").
+const GROUP_SEPARATOR = " ";
 function groupThousands(value) {
   const rounded = Math.round(value);
   const sign = rounded < 0 ? "-" : "";
-  return sign + String(Math.abs(rounded)).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return sign + String(Math.abs(rounded)).replace(/\B(?=(\d{3})+(?!\d))/g, GROUP_SEPARATOR);
 }
 
 export function formatPrice(value, locale = "uz") {


### PR DESCRIPTION
`dev` allaqachon collections feature'ini o'z ichiga oladi (PR #71). Bu PR `feat/book-collections`'dagi qolgan deltani — **kartochka birxilligi fix'ini** (PR #72) — `dev`'ga olib keladi.

## O'zgarishlar (4 fayl)
- `BookChatRow` bitta content ustuniga ko'chirildi — sarlavha har qanday kenglikda ko'rinadi (shop detail / book-detail seller'da kesilish/yo'qolish tuzatildi)
- Tip-belgisi hamma joyda bitta rangli chip; ortiqcha "Sotiladigan" chip narx bor joyda olib tashlandi
- Muallif 1 qatorga, skeleton yangi layout'ga moslandi
- Narx ajratuvchisi bo'sh joy (`160 000 so'm`), hydration-safe

## Tekshiruv
eslint toza · 175 unit test ✓ · Playwright 1280px/390px/loading render

🤖 Generated with [Claude Code](https://claude.com/claude-code)