### PR TITLE
fix(book-card): professional redesign + stop CTA clipping in profile/wishlist grids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,7 @@ Bularni o'chirmang — context manbasi sifatida saqlanadi. Lekin **fakt manbasi 
 
 ### Performance optimizations (`performance.css`)
 
-- `content-visibility: auto` — kartochka va image'lar offscreen render'sini "abstract box" qiladi.
+- `content-visibility: auto` — faqat `img[loading="lazy"]` uchun (offscreen rasm dekodini kechiktiradi). ⚠️ **`.product-card` (BookCard)'da ataylab ISHLATILMAYDI**: fixed `contain-intrinsic-size` placeholder kartochkaning haqiqiy balandligidan past bo'lganda pastki qismini (yashil "Batafsil ko'rish" CTA tugmasi) kesib qo'yardi va scroll paytida kartochkalar balandligi sakrab, grid notekis ko'rinardi. Kartochkalar kichik + muqovalar allaqachon `loading="lazy"`, shuning uchun containment foydadan ko'ra zarar keltirardi. (`.vendor-card` ham olib tashlandi — ShopCard migratsiyasidan keyin o'lik klass.)
 - `will-change` — slider va hover joylari uchun.
 - `@media (prefers-reduced-motion)` — accessibility.
 

--- a/src/app/[locale]/globals.scss
+++ b/src/app/[locale]/globals.scss
@@ -365,14 +365,263 @@ body.body-no-scroll {
   }
 }
 
-// ─── BookCard action buttons (top-right corner) ──────────────────────────────
-// Always-visible action chips. Replaces the previous low-contrast
-// outline-button approach where icons looked invisible against the white
-// card surface until the user hovered.
+// ─── BookCard — professional marketplace card ────────────────────────────────
+// Full-bleed cover (overlay badges + engagement stats) over a clean padded
+// content well with a pinned CTA. One card primitive for the profile, wishlist,
+// public-profile and archive grids (`shared/BookGrid`, 2 / 3 / 4 columns).
+// Everything visual lives here so the JSX root stays `.book-card .product-card`.
+.book-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--surface-card, #ffffff);
+  border: 1px solid var(--border-subtle, rgba(15, 23, 42, 0.08));
+  border-radius: 16px;
+  overflow: hidden; // clip the full-bleed cover to the card's corner radius
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-elevated, 0 12px 24px rgba(15, 23, 42, 0.1));
+    border-color: var(--main-200, hsl(148, 45%, 82%));
+  }
+
+  // ── Cover ────────────────────────────────────────────────────────────────
+  &__thumb {
+    position: relative;
+    display: block;
+    aspect-ratio: 3 / 4;
+    width: 100%;
+    overflow: hidden;
+    background-color: var(--neutral-50, #f8fafc);
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      transition: transform 0.35s ease;
+    }
+  }
+
+  &:hover &__thumb img {
+    transform: scale(1.05);
+  }
+
+  // Discount chip — pinned top-left over the cover.
+  &__cover-badges {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    z-index: 2;
+    pointer-events: none;
+  }
+
+  &__cover-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    height: 24px;
+    padding: 0 9px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+    color: #ffffff;
+    background-color: var(--danger-600, #dc2626);
+    box-shadow: 0 1px 4px rgba(15, 23, 42, 0.18);
+  }
+
+  // Views / likes — subtle overlay along the bottom of the cover.
+  &__cover-stats {
+    position: absolute;
+    inset: auto 0 0 0;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 22px 12px 8px;
+    background: linear-gradient(to top, rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0));
+    z-index: 1;
+    pointer-events: none;
+  }
+
+  &__cover-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #ffffff;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+
+    i {
+      font-size: 14px;
+    }
+  }
+
+  // ── Content well ───────────────────────────────────────────────────────────
+  &__content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    gap: 6px;
+    padding: 12px;
+  }
+
+  &__title {
+    margin: 0;
+    font-weight: 600;
+    line-height: 1.3;
+    font-size: clamp(14px, 1.5vw, 16px);
+
+    .link {
+      color: var(--text-primary, #0f172a);
+      text-decoration: none;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      // Reserve two lines so 1- and 2-line titles align across the grid.
+      min-height: 2.6em;
+      word-break: break-word;
+      transition: color 0.15s ease;
+    }
+
+    .link:hover {
+      color: var(--main-600, hsl(148, 59%, 39%));
+    }
+  }
+
+  // Author · year, one muted line.
+  &__byline {
+    margin: 0;
+    font-size: 12.5px;
+    color: var(--text-muted, #64748b);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__price-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 2px;
+  }
+
+  &__price-current {
+    font-size: clamp(15px, 1.6vw, 18px);
+    font-weight: 800;
+    color: var(--main-600, hsl(148, 59%, 39%));
+  }
+
+  &__price-old {
+    font-size: 12.5px;
+    color: var(--text-muted, #94a3b8);
+    text-decoration: line-through;
+  }
+
+  // Type chip (gift / exchange / rent) beside the price — colours from
+  // BOOK_TYPE_VISUALS via inline style; matches BookChatRow / BookDetails.
+  &__type-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    height: 22px;
+    padding: 0 9px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+
+    i {
+      font-size: 12px;
+    }
+  }
+
+  // Seller / location footer — compact, muted, divided from the body.
+  &__footer {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    margin-top: 2px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border-subtle, rgba(15, 23, 42, 0.06));
+  }
+
+  &__footer-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    font-size: 11.5px;
+    color: var(--text-muted, #64748b);
+
+    i {
+      font-size: 13px;
+      color: var(--main-600, hsl(148, 59%, 39%));
+      flex-shrink: 0;
+    }
+
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  // ── CTA — pinned to the bottom so it aligns across the row. ────────────────
+  &__cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-top: auto;
+    padding: 9px 14px;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none;
+    color: var(--main-700, hsl(148, 59%, 31%));
+    background-color: var(--main-50, hsl(148, 59%, 95%));
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease;
+
+    i {
+      font-size: 15px;
+      transition: transform 0.15s ease;
+    }
+
+    &:hover {
+      background-color: var(--main-600, hsl(148, 59%, 39%));
+      color: #ffffff;
+
+      i {
+        transform: translateX(3px);
+      }
+    }
+  }
+}
+
+// ─── BookCard action buttons (top-right of the cover) ────────────────────────
+// Always-visible glassy chips. Replaces the previous low-contrast outline
+// buttons whose icons looked invisible against the white card until hover.
 .book-card__actions {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 10px;
+  right: 10px;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -380,17 +629,19 @@ body.body-no-scroll {
 }
 
 .book-card__action-btn {
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  background-color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
   color: var(--neutral-700, #475569);
-  font-size: 18px;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  font-size: 17px;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.16);
   transition:
     transform 0.15s ease,
     background-color 0.15s ease,
@@ -407,7 +658,8 @@ body.body-no-scroll {
   &:hover,
   &:focus-visible {
     transform: translateY(-1px);
-    box-shadow: 0 4px 10px rgba(15, 23, 42, 0.12);
+    background-color: #ffffff;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.22);
   }
 
   &:focus-visible {
@@ -434,7 +686,6 @@ body.body-no-scroll {
     color: var(--main-700, hsl(148, 59%, 31%));
 
     &:hover {
-      background-color: var(--main-50, hsl(148, 59%, 95%));
       color: var(--main-700, hsl(148, 59%, 31%));
     }
   }
@@ -443,7 +694,6 @@ body.body-no-scroll {
     color: #b45309;
 
     &:hover {
-      background-color: #fef3c7;
       color: #92400e;
     }
   }
@@ -452,7 +702,6 @@ body.body-no-scroll {
     color: var(--main-700, hsl(148, 59%, 31%));
 
     &:hover {
-      background-color: var(--main-50, hsl(148, 59%, 95%));
       color: var(--main-700, hsl(148, 59%, 31%));
     }
   }
@@ -461,7 +710,6 @@ body.body-no-scroll {
     color: var(--danger-600, #dc2626);
 
     &:hover {
-      background-color: #fee2e2;
       color: var(--danger-700, #b91c1c);
     }
   }
@@ -470,7 +718,6 @@ body.body-no-scroll {
     color: var(--main-700, hsl(148, 59%, 31%));
 
     &:hover {
-      background-color: var(--main-50, hsl(148, 59%, 95%));
       color: var(--main-700, hsl(148, 59%, 31%));
     }
   }
@@ -480,151 +727,13 @@ body.body-no-scroll {
   .book-card__actions {
     top: 8px;
     right: 8px;
-    gap: 4px;
+    gap: 5px;
   }
 
   .book-card__action-btn {
-    width: 34px;
-    height: 34px;
-    font-size: 16px;
-  }
-}
-
-// ─── BookCard responsive content layout ──────────────────────────────────────
-.book-card {
-  display: flex;
-  flex-direction: column;
-  background-color: #ffffff;
-
-  &__thumb {
-    aspect-ratio: 3 / 4;
-    width: 100%;
-    min-height: 0;
-    overflow: hidden;
-    border-radius: 12px;
-    background-color: var(--neutral-50, #f8fafc);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      transition: transform 0.25s ease;
-    }
-  }
-
-  &:hover .book-card__thumb img {
-    transform: scale(1.04);
-  }
-
-  &__content {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-  }
-
-  &__title {
-    margin: 0;
-    font-weight: 600;
-    line-height: 1.3;
-    font-size: clamp(14px, 1.6vw, 17px);
-
-    .link {
-      color: var(--neutral-900, #0f172a);
-      text-decoration: none;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-      // Reserve two lines so 1-line and 2-line titles align across the grid
-      // (uniform card heads), while still clamping longer titles with an
-      // ellipsis instead of clipping mid-word.
-      min-height: 2.6em;
-      word-break: break-word;
-    }
-  }
-
-  &__meta-row {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    min-width: 0;
-  }
-
-  &__meta-icon {
-    color: var(--main-600, hsl(148, 59%, 39%));
-    font-size: 14px;
-    flex-shrink: 0;
-  }
-
-  &__meta-text {
-    font-size: clamp(11px, 1.2vw, 13px);
-    color: var(--neutral-500, #64748b);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  &__seller {
-    color: var(--neutral-600, #475569);
-  }
-
-  &__price {
-    display: flex;
-    align-items: baseline;
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-
-  &__price-current {
-    font-size: clamp(14px, 1.6vw, 17px);
-    font-weight: 700;
-    color: var(--neutral-900, #0f172a);
-  }
-
-  &__price-old {
-    font-size: clamp(12px, 1.3vw, 14px);
-    color: var(--neutral-400, #94a3b8);
-    text-decoration: line-through;
-  }
-
-  &__counters {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  &__counter {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--neutral-500, #64748b);
-
-    i {
-      font-size: 14px;
-    }
-  }
-
-  &__cta {
-    font-size: clamp(12px, 1.3vw, 14px);
-    padding: 10px 18px;
-    font-weight: 600;
-    // Pin the CTA to the bottom so it lines up across cards regardless of how
-    // many meta rows (year / price / counters) a given book has → uniform grid.
-    margin-top: auto;
-  }
-}
-
-@media (max-width: 575.98px) {
-  .book-card {
-    &__cta {
-      padding: 9px 14px;
-      font-size: 13px;
-    }
+    width: 32px;
+    height: 32px;
+    font-size: 15px;
   }
 }
 

--- a/src/app/[locale]/performance.css
+++ b/src/app/[locale]/performance.css
@@ -42,35 +42,18 @@ img[loading="lazy"] {
   will-change: background-color, border-color;
 }
 
-/* Optimize product cards.
-   The intrinsic-size is the placeholder height an off-screen card reserves
-   before its content is painted. It MUST be >= the card's real rendered height,
-   otherwise content-visibility clips the bottom of the card (the "Batafsil
-   ko'rish" CTA was getting cut off). Measured BookCard heights in the BookGrid:
-   2-col (xs/sm) ~474px, 3-col (md/lg) ~527px, 4-col (xl) ~610px. We round up per
-   breakpoint and add the `auto` keyword so the browser swaps in the exact
-   measured height after the first paint (no scroll jump on revisit). */
-.product-card {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 500px;
-}
-
-@media (min-width: 768px) {
-  .product-card {
-    contain-intrinsic-size: auto 540px;
-  }
-}
-
-@media (min-width: 1200px) {
-  .product-card {
-    contain-intrinsic-size: auto 620px;
-  }
-}
-
-.vendor-card {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 360px;
-}
+/* NOTE — `content-visibility: auto` is intentionally NOT used on `.product-card`
+   (BookCard). It reserves a single fixed placeholder height per breakpoint
+   (`contain-intrinsic-size`) for off-screen cards; whenever a card's real
+   height exceeds that reservation the browser clips its bottom — i.e. the green
+   "Batafsil ko'rish" CTA button got cut off — and because real card heights
+   vary with content (publication-year row, 2-line title, owner location,
+   discounted-price line) the placeholder also made cards jump and look uneven
+   as they scrolled into view. The cards are small and their covers are already
+   `loading="lazy"` (the real rendering win), so the containment bought little
+   while breaking layout. Rendering at natural height keeps the grid consistent
+   and the CTA always visible. (`.vendor-card` removed too — that class is dead
+   since the ShopCard migration.) */
 
 /* Critical CSS - Prevent FOUC */
 html {

--- a/src/components/BookCard.jsx
+++ b/src/components/BookCard.jsx
@@ -8,6 +8,7 @@ import { formatPrice } from "@/utils/formatPrice";
 import { openShareSheet } from "@/lib/shareSheet";
 import { resolveMediaUrl } from "@/utils/mediaUrl";
 import { bookOwnerLocation } from "@/utils/location";
+import { bookTypeVisual, bookTypeI18nKey } from "@/utils/bookType";
 import Icon from "@/components/Icon";
 import { useToast } from "./Toast";
 
@@ -74,6 +75,17 @@ const BookCard = ({
   const showEditButton = showEditForOwn && isOwnBook && onEdit;
   const ownerLocation = bookOwnerLocation(book);
 
+  // Visual identity + offer state for the price row / cover. `seller` is the
+  // default (no chip — the price already implies a sale); gift/exchange/rent
+  // get a coloured type chip beside the price, matching BookChatRow.
+  const typeVisual = bookTypeVisual(book.type);
+  const isMonetary = book.type !== "gift" && book.type !== "exchange";
+  const showTypeChip = Boolean(typeVisual) && book.type !== "seller";
+  const authorText = getLocalizedField("author") || tCommon("unknownAuthor");
+  const byline = book.publication_year ? `${authorText} · ${book.publication_year}` : authorText;
+  const viewCount = book.view_count || 0;
+  const showStats = viewCount > 0 || likeCount > 0;
+
   const handleShare = (e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -113,7 +125,7 @@ const BookCard = ({
   };
 
   return (
-    <div className="book-card product-card h-100 p-8 p-sm-12 border border-gray-100 hover-border-main-600 rounded-16 position-relative transition-2">
+    <div className="book-card product-card">
       <div className="book-card__actions">
         <button
           type="button"
@@ -191,47 +203,51 @@ const BookCard = ({
           </button>
         )}
       </div>
-      {book.percentage && (
-        <span className="product-card__badge bg-danger-600 px-8 py-4 text-sm text-white">
-          -{book.percentage}%
-        </span>
-      )}
 
-      <Link href={`/book-details/${book.id}`} className="book-card__thumb flex-center">
+      <Link href={`/book-details/${book.id}`} className="book-card__thumb">
         <img
           src={resolveMediaUrl(book.picture, "/assets/images/thumbs/product-img7.png")}
           alt={book.name}
           loading="lazy"
         />
+
+        {book.percentage ? (
+          <div className="book-card__cover-badges">
+            <span className="book-card__cover-badge">-{book.percentage}%</span>
+          </div>
+        ) : null}
+
+        {showStats && (
+          <div className="book-card__cover-stats">
+            {viewCount > 0 && (
+              <span className="book-card__cover-stat">
+                <Icon className="ph-fill ph-eye" aria-hidden="true" />
+                {viewCount}
+              </span>
+            )}
+            {likeCount > 0 && (
+              <span className="book-card__cover-stat">
+                <Icon className="ph-fill ph-heart" aria-hidden="true" />
+                {likeCount}
+              </span>
+            )}
+          </div>
+        )}
       </Link>
 
-      <div className="book-card__content mt-12">
-        <h6 className="book-card__title mb-8">
-          <Link href={`/book-details/${book.id}`} className="link text-line-2">
+      <div className="book-card__content">
+        <h6 className="book-card__title">
+          <Link href={`/book-details/${book.id}`} className="link">
             {getLocalizedField("name") || tBookCard("noName")}
           </Link>
         </h6>
 
-        <div className="book-card__meta-row mb-8">
-          <Icon className="ph-fill ph-user book-card__meta-icon" aria-hidden="true" />
-          <span className="book-card__meta-text">
-            {getLocalizedField("author") || tCommon("unknownAuthor")}
-          </span>
-        </div>
+        <p className="book-card__byline" title={byline}>
+          {byline}
+        </p>
 
-        {book.publication_year && (
-          <div className="book-card__meta-row mb-8">
-            <Icon className="ph-fill ph-calendar-blank book-card__meta-icon" aria-hidden="true" />
-            <span className="book-card__meta-text">{book.publication_year}</span>
-          </div>
-        )}
-
-        <div className="book-card__price mb-8">
-          {book.type === "gift" ? (
-            <span className="book-card__price-current text-success">{tType("gift")}</span>
-          ) : book.type === "exchange" ? (
-            <span className="book-card__price-current text-warning">{tType("exchange")}</span>
-          ) : book.price ? (
+        <div className="book-card__price-row">
+          {isMonetary && book.price ? (
             <>
               <span className="book-card__price-current">
                 {formatPrice(book.discount_price || book.price, locale)}
@@ -241,44 +257,38 @@ const BookCard = ({
               )}
             </>
           ) : null}
-        </div>
-
-        <div className="book-card__counters">
-          <span className="book-card__counter">
-            <Icon className="ph ph-eye" aria-hidden="true" />
-            {book.view_count || 0}
-          </span>
-          {likeCount > 0 && (
-            <span className="book-card__counter">
-              <Icon className="ph ph-heart" aria-hidden="true" />
-              {likeCount}
-            </span>
-          )}
-        </div>
-
-        <div className="book-card__meta-row mt-8 justify-content-between">
-          <span className="d-inline-flex align-items-center gap-4" style={{ minWidth: 0 }}>
-            <Icon className="ph-fill ph-storefront book-card__meta-icon" aria-hidden="true" />
-            <span className="book-card__meta-text book-card__seller">
-              {`${tCommon("seller")}: ${sellerName}`}
-            </span>
-          </span>
-          {ownerLocation && (
+          {showTypeChip && (
             <span
-              className="d-inline-flex align-items-center gap-4 flex-shrink-0"
-              style={{ maxWidth: "58%" }}
-              title={ownerLocation}
+              className="book-card__type-chip"
+              style={{ backgroundColor: typeVisual.bg, color: typeVisual.color }}
             >
-              <Icon className="ph-fill ph-map-pin book-card__meta-icon" aria-hidden="true" />
-              <span className="book-card__meta-text">{ownerLocation}</span>
+              <Icon className={typeVisual.icon} aria-hidden="true" />
+              {tType(bookTypeI18nKey(book.type))}
             </span>
           )}
         </div>
 
-        <Link
-          href={`/book-details/${book.id}`}
-          className="book-card__cta btn bg-main-50 text-main-600 hover-bg-main-600 hover-text-white rounded-pill flex-align gap-8 mt-16 w-100 justify-content-center"
-        >
+        {(sellerName || ownerLocation) && (
+          <div className="book-card__footer">
+            {sellerName && (
+              <span
+                className="book-card__footer-item"
+                title={`${tCommon("seller")}: ${sellerName}`}
+              >
+                <Icon className="ph-fill ph-storefront" aria-hidden="true" />
+                <span>{sellerName}</span>
+              </span>
+            )}
+            {ownerLocation && (
+              <span className="book-card__footer-item" title={ownerLocation}>
+                <Icon className="ph-fill ph-map-pin" aria-hidden="true" />
+                <span>{ownerLocation}</span>
+              </span>
+            )}
+          </div>
+        )}
+
+        <Link href={`/book-details/${book.id}`} className="book-card__cta">
           {tBookCard("viewDetails")} <Icon className="ph ph-arrow-right" aria-hidden="true" />
         </Link>
       </div>

--- a/src/components/shared/BookCardSkeleton.jsx
+++ b/src/components/shared/BookCardSkeleton.jsx
@@ -6,13 +6,19 @@ import React from "react";
  * grid doesn't reflow when real cards swap in. Shimmer comes from `.kz-skel`.
  */
 const BookCardSkeleton = () => (
-  <div className="book-card h-100 p-8 p-sm-12 border border-gray-100 rounded-16" aria-hidden="true">
-    <div className="kz-skel" style={{ width: "100%", aspectRatio: "3 / 4", borderRadius: 12 }} />
-    <div className="mt-12 d-flex flex-column" style={{ gap: 8 }}>
-      <div className="kz-skel" style={{ height: 14, width: "85%" }} />
-      <div className="kz-skel" style={{ height: 12, width: "55%" }} />
-      <div className="kz-skel" style={{ height: 16, width: "40%" }} />
-      <div className="kz-skel mt-8" style={{ height: 38, width: "100%", borderRadius: 999 }} />
+  <div className="book-card" aria-hidden="true">
+    <div className="book-card__thumb">
+      <div className="kz-skel" style={{ width: "100%", height: "100%" }} />
+    </div>
+    <div className="book-card__content">
+      <div className="kz-skel" style={{ height: 14, width: "90%" }} />
+      <div className="kz-skel" style={{ height: 14, width: "60%" }} />
+      <div className="kz-skel" style={{ height: 12, width: "45%" }} />
+      <div className="kz-skel" style={{ height: 18, width: "50%", marginTop: 2 }} />
+      <div
+        className="kz-skel"
+        style={{ height: 36, width: "100%", borderRadius: 999, marginTop: "auto" }}
+      />
     </div>
   </div>
 );


### PR DESCRIPTION
## Muammo
Profil va wishlist ro'yxatlarida BookCard'ning yashil **"Batafsil ko'rish"** CTA tugmasi kesilib qolardi, va kartochkalar scroll paytida sakrab, notekis ko'rinardi.

## Sabab
`.product-card` (BookCard) ustidagi `content-visibility: auto` + qat'iy `contain-intrinsic-size`: ekrandan tashqari kartochka uchun band qilingan placeholder balandlik haqiqiy balandlikdan past bo'lganda pastki qism (CTA) kesilardi; va band qilingan balandlik haqiqiyga teng emasligi sababli grid notekis ko'rinardi.

## O'zgarishlar
- **`performance.css`**: `.product-card`'dan `content-visibility` olib tashlandi (muqovalar allaqachon `loading="lazy"`). O'lik `.vendor-card` qoidasi ham olib tashlandi.
- **BookCard redizayn** (`BookCard.jsx` + `globals.scss`): to'liq-bleed 3:4 muqova + overlay (chegirma badge, ko'rish/layk statistikasi), glassy action tugmalar, toza kontent (sarlavha, "muallif · yil", narx + type chip `BOOK_TYPE_VISUALS`dan, sotuvchi/lokatsiya footer), pastga yopishtirilgan CTA → har qatordagi kartochkalar bir tekis. Hover lift + soya + zoom. Hammasi design-token orqali (dark-mode xavfsiz).
- **`BookCardSkeleton.jsx`**: yangi layout'ga moslandi (yuklanishda sakrash yo'q).
- **`CLAUDE.md`**: hujjat yangilandi (content-visibility endi faqat lazy img uchun).

## Test
- ESLint ✓ · Prettier ✓ · i18n (911 kalit sinxron, yangi kalit yo'q) ✓ · webpack compile ✓
- ⚠️ Manual: 360 / 768 / 1440px da profil & wishlist ro'yxatini ko'rish kerak (lokal brauzer mavjud emas edi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)