### PR TITLE
feat(ui): design-system tokens + shared SectionHeader + frosted sticky header

### DIFF
--- a/src/app/[locale]/globals.scss
+++ b/src/app/[locale]/globals.scss
@@ -66,6 +66,36 @@
   --shadow-card: 0 2px 6px rgba(15, 23, 42, 0.06);
   --shadow-elevated: 0 4px 12px rgba(15, 23, 42, 0.1);
 
+  // ── Design-system scales (minimalist / professional) ──────────────────────
+  // Opt-in tokens so surfaces share one rhythm. Existing components keep their
+  // hard-coded values; new/polished ones reference these for consistency.
+
+  // Corner radius
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 22px;
+  --radius-pill: 999px;
+
+  // Elevation (soft, low-contrast — depth without heaviness)
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04), 0 1px 3px rgba(15, 23, 42, 0.06);
+  --shadow-hover: 0 6px 18px rgba(15, 23, 42, 0.09);
+  --shadow-pop: 0 14px 36px rgba(15, 23, 42, 0.14);
+
+  // Focus ring (keyboard a11y) — brand-tinted, consistent everywhere
+  --ring: 0 0 0 3px hsl(148 59% 39% / 0.35);
+
+  // Motion — one easing/duration language across the app
+  --dur-fast: 0.15s;
+  --dur-base: 0.22s;
+  --dur-slow: 0.4s;
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+
+  // Layout rhythm
+  --section-gap: clamp(28px, 4vw, 48px);
+  --container-max: 1200px;
+
   color-scheme: light;
 }
 
@@ -89,6 +119,10 @@
 
   --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.4);
   --shadow-elevated: 0 6px 16px rgba(0, 0, 0, 0.5);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-hover: 0 6px 18px rgba(0, 0, 0, 0.5);
+  --shadow-pop: 0 14px 36px rgba(0, 0, 0, 0.6);
+  --ring: 0 0 0 3px hsl(148 59% 49% / 0.45);
 
   color-scheme: dark;
 }
@@ -734,6 +768,47 @@ body.body-no-scroll {
     width: 32px;
     height: 32px;
     font-size: 15px;
+  }
+}
+
+// ─── Section header "see all" link (shared/SectionHeader.jsx) ────────────────
+// Pill link to the right of a section title. Hover/focus live here (CSS) rather
+// than as inline JS handlers, and the caret nudges right on hover for a subtle,
+// consistent micro-interaction across every home/list section.
+.kz-see-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding: 6px 12px;
+  border-radius: var(--radius-pill, 999px);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  color: var(--main-600, hsl(148, 59%, 39%));
+  text-decoration: none;
+  background-color: transparent;
+  transition:
+    background-color var(--dur-fast, 0.15s) var(--ease-out, ease),
+    color var(--dur-fast, 0.15s) var(--ease-out, ease);
+
+  i {
+    font-size: 14px;
+    transition: transform var(--dur-fast, 0.15s) var(--ease-out, ease);
+  }
+
+  &:hover {
+    background-color: var(--surface-muted);
+  }
+
+  &:hover i {
+    transform: translateX(2px);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--ring, 0 0 0 3px hsl(148 59% 39% / 0.35));
   }
 }
 

--- a/src/components/HeaderOne.jsx
+++ b/src/components/HeaderOne.jsx
@@ -372,12 +372,26 @@ const HeaderOne = () => {
           background: var(--surface-card, #fff);
           border-bottom: 1px solid transparent;
           transition:
-            box-shadow 0.18s ease,
-            border-color 0.18s ease;
+            box-shadow var(--dur-base, 0.22s) var(--ease-out, ease),
+            border-color var(--dur-base, 0.22s) var(--ease-out, ease),
+            background-color var(--dur-base, 0.22s) var(--ease-out, ease);
         }
+        /* Once scrolled, the bar turns into a frosted-glass surface: a
+           translucent fill + backdrop blur lets page content tint through
+           subtly (iOS / Telegram style) rather than a flat opaque slab. */
         .kz-header--scrolled {
+          background: color-mix(in srgb, var(--surface-card, #fff) 82%, transparent);
+          -webkit-backdrop-filter: blur(12px) saturate(150%);
+          backdrop-filter: blur(12px) saturate(150%);
           border-bottom-color: var(--border-subtle, #e5e7eb);
-          box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
+          box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+        }
+        /* Browsers without backdrop-filter keep a solid bar (no content
+           bleeding through a half-transparent header). */
+        @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+          .kz-header--scrolled {
+            background: var(--surface-card, #fff);
+          }
         }
         .kz-header__inner {
           max-width: 1240px;

--- a/src/components/home/HomeBookList.jsx
+++ b/src/components/home/HomeBookList.jsx
@@ -2,11 +2,10 @@
 
 import React, { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Box, Stack, Typography } from "@mui/material";
-import { Link } from "@/i18n/navigation";
+import { Box } from "@mui/material";
 import { getBooks } from "@/services/books";
 import BookRowGrid from "@/components/shared/BookRowGrid";
-import Icon from "@/components/Icon";
+import SectionHeader from "@/components/shared/SectionHeader";
 
 /**
  * Telegram chat-row inspired home section. Lists up to `limit` books filtered
@@ -56,55 +55,7 @@ const HomeBookList = ({ type, ownerType, titleKey, viewAllHref, limit = 6, initi
   return (
     <Box component="section" sx={{ bgcolor: "var(--surface-page)", py: { xs: 2, md: 2.75 } }}>
       <Box sx={{ maxWidth: 1240, mx: "auto", px: { xs: 2, md: 3 } }}>
-        {/* Telegram-style channel header: title left, pill "see all" right,
-            generous gap so long titles never crash into the link. Title
-            ellipses on overflow instead of wrapping under the link. */}
-        <Stack direction="row" spacing={2} sx={{ alignItems: "center", mb: 1.5, minHeight: 32 }}>
-          <Typography
-            component="h2"
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              fontSize: { xs: 16, md: 18 },
-              fontWeight: 700,
-              letterSpacing: "-0.01em",
-              color: "var(--text-primary)",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              lineHeight: 1.25,
-            }}
-          >
-            {t(titleKey)}
-          </Typography>
-          <Link
-            href={viewAllHref}
-            aria-label={`${t(titleKey)} — ${t("seeAll")}`}
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 4,
-              flexShrink: 0,
-              fontSize: 13,
-              fontWeight: 600,
-              color: "var(--main-600, hsl(148, 59%, 39%))",
-              textDecoration: "none",
-              padding: "6px 12px",
-              borderRadius: 999,
-              background: "transparent",
-              transition: "background 0.15s ease",
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.background = "var(--surface-muted)";
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background = "transparent";
-            }}
-          >
-            {t("seeAll")}
-            <Icon className="ph ph-caret-right" aria-hidden="true" style={{ fontSize: 14 }} />
-          </Link>
-        </Stack>
+        <SectionHeader title={t(titleKey)} href={viewAllHref} seeAllLabel={t("seeAll")} />
 
         <BookRowGrid books={books} loading={loading} skeletonCount={limit} showTypeBadge={!type} />
       </Box>

--- a/src/components/home/HomeCollectionsRow.jsx
+++ b/src/components/home/HomeCollectionsRow.jsx
@@ -2,11 +2,10 @@
 
 import React, { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Box, Stack, Typography } from "@mui/material";
-import { Link } from "@/i18n/navigation";
+import { Box } from "@mui/material";
 import { getCollections } from "@/services/collections";
 import CollectionRowGrid from "@/components/shared/CollectionRowGrid";
-import Icon from "@/components/Icon";
+import SectionHeader from "@/components/shared/SectionHeader";
 
 /**
  * Home "Collections / bundles" row — same channel-header + responsive grid as
@@ -38,41 +37,7 @@ const HomeCollectionsRow = ({ limit = 6 }) => {
   return (
     <Box component="section" sx={{ bgcolor: "var(--surface-page)", py: { xs: 2, md: 2.75 } }}>
       <Box sx={{ maxWidth: 1240, mx: "auto", px: { xs: 2, md: 3 } }}>
-        <Stack direction="row" spacing={2} sx={{ alignItems: "center", mb: 1.5, minHeight: 32 }}>
-          <Typography
-            component="h2"
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              fontSize: { xs: 16, md: 18 },
-              fontWeight: 700,
-              color: "var(--text-primary)",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {t("homeTitle")}
-          </Typography>
-          <Link
-            href="/collections"
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 4,
-              flexShrink: 0,
-              fontSize: 13,
-              fontWeight: 600,
-              color: "var(--main-600, hsl(148, 59%, 39%))",
-              textDecoration: "none",
-              padding: "6px 12px",
-              borderRadius: 999,
-            }}
-          >
-            {t("seeAll")}
-            <Icon className="ph ph-caret-right" aria-hidden="true" style={{ fontSize: 14 }} />
-          </Link>
-        </Stack>
+        <SectionHeader title={t("homeTitle")} href="/collections" seeAllLabel={t("seeAll")} />
         <CollectionRowGrid collections={collections} loading={loading} skeletonCount={limit} />
       </Box>
     </Box>

--- a/src/components/home/HomeShopsRow.jsx
+++ b/src/components/home/HomeShopsRow.jsx
@@ -2,12 +2,11 @@
 
 import React, { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Box, Stack, Typography } from "@mui/material";
-import { Link } from "@/i18n/navigation";
+import { Box } from "@mui/material";
 import { getHomePageShops } from "@/services/shops";
 import ShopCard from "@/components/shop/ShopCard";
 import ShopCardSkeleton from "@/components/shared/ShopCardSkeleton";
-import Icon from "@/components/Icon";
+import SectionHeader from "@/components/shared/SectionHeader";
 
 /**
  * Home-page shops row.
@@ -45,52 +44,7 @@ const HomeShopsRow = ({ initialShops }) => {
   return (
     <Box sx={{ bgcolor: "var(--surface-page)", py: { xs: 2, md: 3 } }}>
       <Box sx={{ maxWidth: 1240, mx: "auto", px: { xs: 2, md: 3 } }}>
-        <Stack direction="row" spacing={2} sx={{ alignItems: "center", mb: 1.5, minHeight: 32 }}>
-          <Typography
-            component="h2"
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              fontSize: { xs: 17, md: 20 },
-              fontWeight: 700,
-              letterSpacing: "-0.01em",
-              color: "var(--text-primary)",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              lineHeight: 1.25,
-            }}
-          >
-            {t("title")}
-          </Typography>
-          <Link
-            href="/shops"
-            aria-label={`${t("title")} — ${t("seeAll")}`}
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 4,
-              flexShrink: 0,
-              fontSize: 13,
-              fontWeight: 600,
-              color: "var(--main-600, hsl(148, 59%, 39%))",
-              textDecoration: "none",
-              padding: "6px 12px",
-              borderRadius: 999,
-              background: "transparent",
-              transition: "background 0.15s ease",
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.background = "var(--surface-muted)";
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background = "transparent";
-            }}
-          >
-            {t("seeAll")}
-            <Icon className="ph ph-caret-right" aria-hidden="true" style={{ fontSize: 14 }} />
-          </Link>
-        </Stack>
+        <SectionHeader title={t("title")} href="/shops" seeAllLabel={t("seeAll")} size="lg" />
 
         {/* Grid: 1 col on mobile (full-width rows), 2 col on tablet,
             3 col on desktop. Each cell hosts one `ShopCard`. */}

--- a/src/components/shared/SectionHeader.jsx
+++ b/src/components/shared/SectionHeader.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Stack, Typography } from "@mui/material";
+import { Link } from "@/i18n/navigation";
+import Icon from "@/components/Icon";
+
+/**
+ * Shared section header for the home feed and other list surfaces: a title on
+ * the left, an optional "see all →" pill link on the right. Single source of
+ * truth so every section shares one rhythm, sizing, and hover/focus treatment
+ * (this markup was previously duplicated ~6× with inline JS hover handlers
+ * mutating `style`). Hover + keyboard focus now live in CSS (`.kz-see-all` in
+ * globals.scss), which is cheaper and gives a consistent micro-interaction.
+ *
+ * Props:
+ * - title       section title (string)
+ * - href        optional "see all" target (next-intl Link)
+ * - seeAllLabel label for the see-all link (required when `href` is set)
+ * - as          heading level/tag (default "h2")
+ * - size        "md" (16/18px) default | "lg" (17/20px) for top-level rows
+ */
+const SectionHeader = ({ title, href, seeAllLabel, as = "h2", size = "md" }) => {
+  const fontSize = size === "lg" ? { xs: 17, md: 20 } : { xs: 16, md: 18 };
+
+  return (
+    <Stack direction="row" spacing={2} sx={{ alignItems: "center", mb: 1.5, minHeight: 32 }}>
+      <Typography
+        component={as}
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          fontSize,
+          fontWeight: 700,
+          letterSpacing: "-0.01em",
+          color: "var(--text-primary)",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          lineHeight: 1.25,
+        }}
+      >
+        {title}
+      </Typography>
+      {href && seeAllLabel ? (
+        <Link href={href} className="kz-see-all" aria-label={`${title} — ${seeAllLabel}`}>
+          {seeAllLabel}
+          <Icon className="ph ph-caret-right" aria-hidden="true" />
+        </Link>
+      ) : null}
+    </Stack>
+  );
+};
+
+export default SectionHeader;


### PR DESCRIPTION
Full-project UX/UI polish'ning **1-iteratsiyasi** — yo'nalish: *minimalist & professional* (mutolaa / Telegram / Amazon ruhida). Bosqichma-bosqich, har biri alohida PR + dev tekshiruvi.

## Bosqich 0 — Dizayn-tizim poydevori (`globals.scss :root`, faqat qo'shimcha, mavjud kodga ta'sir yo'q)
- **Radius shkalasi** (`--radius-sm..pill`), **yumshoq soya shkalasi** (`--shadow-sm/hover/pop`), **brend focus-ring** (`--ring`), **motion tili** (`--dur-*` / `--ease-*`), **layout ritmi** (`--section-gap`, `--container-max`). Dark-mode override'lar bilan.

## Bosqich 1 — Home feed + Header
- **`<SectionHeader>`** (yangi, `shared/`): bo'lim sarlavhasi + "barchasi →" pill linki **6 marta** takrorlanardi, har birida inline JS `onMouseEnter/Leave` style-mutatsiya bilan. Endi bitta token-asosli komponent, hover/focus **CSS'da** (`.kz-see-all`), hover'da strelka suriladi, klaviatura focus-ring'i. `HomeShopsRow`, `HomeCollectionsRow`, `HomeBookList`'ga ulandi (o'lik handlerlar + ishlatilmagan importlar olib tashlandi).
- **Header**: scroll qilinganda **frosted-glass** (yarim-shaffof + backdrop blur, iOS/Telegram uslubi); `backdrop-filter`'siz brauzerlar uchun **solid fallback** (`@supports`). Tranzitsiyalar yangi motion-token'lardan.

## Test
- ESLint ✓ · Prettier ✓ · webpack build **exit 0** (to'liq qurildi) · yangi i18n kalit yo'q.
- ⚠️ Vizual: dev'ga deploydan keyin home + scroll + section header'larni 360/768/1440px da ko'rish kerak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)