### PR TITLE
feat(ui): browse-by-type tabs + polished empty/error states (list & detail)

### DIFF
--- a/src/app/[locale]/globals.scss
+++ b/src/app/[locale]/globals.scss
@@ -812,6 +812,45 @@ body.body-no-scroll {
   }
 }
 
+// ─── Browse-by-type tabs (CommunityBooksPage) ────────────────────────────────
+// Pill links that switch the browse type. Active = filled brand; others are
+// outlined and tint to brand on hover. Horizontal-scrollable on mobile.
+.kz-type-tab {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 16px;
+  border-radius: var(--radius-pill, 999px);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  text-decoration: none;
+  color: var(--text-secondary);
+  background-color: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  transition:
+    background-color var(--dur-fast, 0.15s) var(--ease-out, ease),
+    color var(--dur-fast, 0.15s) var(--ease-out, ease),
+    border-color var(--dur-fast, 0.15s) var(--ease-out, ease);
+
+  &:hover {
+    color: var(--main-700, hsl(148, 59%, 31%));
+    border-color: var(--main-600, hsl(148, 59%, 39%));
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--ring, 0 0 0 3px hsl(148 59% 39% / 0.35));
+  }
+
+  &.is-active {
+    color: #ffffff;
+    background-color: var(--main-600, hsl(148, 59%, 39%));
+    border-color: var(--main-600, hsl(148, 59%, 39%));
+  }
+}
+
 // ─── ProfileTabs (sticky nav, horizontal scroll on mobile) ───────────────────
 // Only the nav row sticks; content scrolls past it. `position: sticky` on a
 // child of an `overflow: hidden` ancestor is broken, so the wrapper must not

--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -22,7 +22,7 @@ import { resolveMediaUrl } from "@/utils/mediaUrl";
 import { localizedField } from "@/utils/localizedField";
 import { bookTypeVisual, bookTypeI18nKey } from "@/utils/bookType";
 import { bookLanguageKey } from "@/utils/bookLanguage";
-import { useRouter, usePathname } from "@/i18n/navigation";
+import { useRouter, usePathname, Link } from "@/i18n/navigation";
 import Icon from "@/components/Icon";
 import { getContactActions } from "@/utils/contactActions";
 import { mapValidationError } from "@/lib/mapValidationError";
@@ -211,18 +211,54 @@ const BookDetails = ({ bookId }) => {
     );
   }
 
-  if (error) {
+  // Error and "not found" share one calm, centered empty-state: an icon, a
+  // clear message, and a way out (browse all books) so the page is never a
+  // dead end.
+  if (error || !book) {
+    const isError = Boolean(error);
     return (
-      <Box sx={{ maxWidth: 720, mx: "auto", px: 2, py: 5, textAlign: "center" }}>
-        <Typography color="error">{error}</Typography>
-      </Box>
-    );
-  }
-
-  if (!book) {
-    return (
-      <Box sx={{ maxWidth: 720, mx: "auto", px: 2, py: 5, textAlign: "center" }}>
-        <Typography sx={{ color: "var(--text-muted)" }}>{tBook("notFound")}</Typography>
+      <Box
+        sx={{
+          maxWidth: 560,
+          mx: "auto",
+          px: 2,
+          py: { xs: 6, md: 9 },
+          textAlign: "center",
+        }}
+      >
+        <Box
+          sx={{
+            width: 72,
+            height: 72,
+            mx: "auto",
+            mb: 2.5,
+            borderRadius: "50%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            bgcolor: "var(--surface-muted)",
+            color: "var(--text-muted)",
+          }}
+        >
+          <Icon
+            className={isError ? "ph ph-warning-circle" : "ph ph-book-open"}
+            style={{ fontSize: 34 }}
+            aria-hidden="true"
+          />
+        </Box>
+        <Typography sx={{ fontSize: 18, fontWeight: 700, color: "var(--text-primary)", mb: 0.75 }}>
+          {isError ? error : tBook("notFound")}
+        </Typography>
+        <Button
+          component={Link}
+          href="/community/all"
+          variant="contained"
+          disableElevation
+          startIcon={<Icon className="ph ph-books" />}
+          sx={{ mt: 1.5, textTransform: "none", fontWeight: 700, borderRadius: 2 }}
+        >
+          {tCommon("viewAll")}
+        </Button>
       </Box>
     );
   }

--- a/src/components/CommunityBooksPage.jsx
+++ b/src/components/CommunityBooksPage.jsx
@@ -15,6 +15,7 @@ import {
 import { getBooks } from "@/services/books";
 import { getBookCategories, getBookSubcategories } from "@/services/categories";
 import { getRegions } from "@/services/regions";
+import { Link } from "@/i18n/navigation";
 import BookRowGrid from "@/components/shared/BookRowGrid";
 import Icon from "@/components/Icon";
 import { mapValidationError } from "@/lib/mapValidationError";
@@ -24,9 +25,16 @@ import { mapValidationError } from "@/lib/mapValidationError";
 // breakpoint.
 const PAGE_SIZE = 24;
 
+// Browse-by-type switcher. Each tab deep-links to its own route so the
+// selection is shareable/bookmarkable and SEO-indexable (the page is
+// route-driven, `[type]`); previously the only way to change type was the
+// URL. Order matches the home feed sections.
+const TYPE_TABS = ["all", "sell", "gift", "exchange", "rent"];
+
 const CommunityBooksPage = ({ type = "all" }) => {
   const t = useTranslations("CommunityPage");
   const tLocation = useTranslations("Location");
+  const tType = useTranslations("BookTypeChips");
   const searchParams = useSearchParams();
 
   const [books, setBooks] = useState([]);
@@ -210,9 +218,36 @@ const CommunityBooksPage = ({ type = "all" }) => {
         >
           {t(`title.${type}`)}
         </Typography>
-        <Typography sx={{ color: "var(--text-secondary)", mb: 2.5 }}>
+        <Typography sx={{ color: "var(--text-secondary)", mb: 2 }}>
           {t(`subtitle.${type}`)}
         </Typography>
+
+        {/* Browse-by-type tabs — horizontal scroll on mobile, no scrollbar.
+            Pill links to each /community/{type}; the active one is filled. */}
+        <Box
+          role="tablist"
+          aria-label={tType("ariaLabel")}
+          sx={{
+            display: "flex",
+            gap: 1,
+            mb: 2.5,
+            overflowX: "auto",
+            pb: 0.5,
+            scrollbarWidth: "none",
+            "&::-webkit-scrollbar": { display: "none" },
+          }}
+        >
+          {TYPE_TABS.map((tab) => (
+            <Link
+              key={tab}
+              href={`/community/${tab}`}
+              className={`kz-type-tab${type === tab ? " is-active" : ""}`}
+              aria-current={type === tab ? "page" : undefined}
+            >
+              {tType(tab)}
+            </Link>
+          ))}
+        </Box>
 
         <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} sx={{ mb: 1.5 }}>
           <TextField
@@ -346,15 +381,31 @@ const CommunityBooksPage = ({ type = "all" }) => {
         {error ? (
           <Box
             sx={{
-              py: 4,
+              py: { xs: 6, md: 8 },
+              px: 2,
               textAlign: "center",
-              color: "var(--text-secondary)",
               border: "1px solid var(--border-subtle)",
-              borderRadius: 3,
+              borderRadius: "var(--radius-lg, 16px)",
               bgcolor: "var(--surface-card)",
             }}
           >
-            {error}
+            <Box
+              sx={{
+                width: 64,
+                height: 64,
+                mx: "auto",
+                mb: 2,
+                borderRadius: "50%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                bgcolor: "var(--surface-muted)",
+                color: "var(--text-muted)",
+              }}
+            >
+              <Icon className="ph ph-warning-circle" style={{ fontSize: 30 }} aria-hidden="true" />
+            </Box>
+            <Typography sx={{ color: "var(--text-secondary)" }}>{error}</Typography>
           </Box>
         ) : (
           <>
@@ -366,19 +417,32 @@ const CommunityBooksPage = ({ type = "all" }) => {
               emptyState={
                 <Box
                   sx={{
-                    py: 6,
+                    py: { xs: 6, md: 8 },
+                    px: 2,
                     textAlign: "center",
-                    color: "var(--text-muted)",
                     border: "1px dashed var(--border-subtle)",
-                    borderRadius: 3,
+                    borderRadius: "var(--radius-lg, 16px)",
                   }}
                 >
-                  <Icon
-                    className="ph ph-book-open"
-                    style={{ fontSize: 40, display: "inline-block", marginBottom: 8 }}
-                    aria-hidden="true"
-                  />
-                  <Typography>{t("noResults")}</Typography>
+                  <Box
+                    sx={{
+                      width: 64,
+                      height: 64,
+                      mx: "auto",
+                      mb: 2,
+                      borderRadius: "50%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      bgcolor: "var(--surface-muted)",
+                      color: "var(--text-muted)",
+                    }}
+                  >
+                    <Icon className="ph ph-book-open" style={{ fontSize: 30 }} aria-hidden="true" />
+                  </Box>
+                  <Typography sx={{ fontWeight: 600, color: "var(--text-primary)" }}>
+                    {t("noResults")}
+                  </Typography>
                 </Box>
               }
             />


### PR DESCRIPTION
Full-project UX/UI polish'ning **2-iteratsiyasi** — kitob ro'yxati (community/browse) va book-details.

## Ro'yxat (CommunityBooksPage)
- **Tur bo'yicha tablar** (Barchasi / Sotiladigan / Sovg'a / Almashish / Ijaraga) — har biri `/community/{type}`'ga pill-link, aktivi to'ldirilgan. Ilgari turni faqat URL'ni qo'lda o'zgartirib almashtirish mumkin edi; endi kashfiyot ko'rinarli va tanlov shareable/SEO-indexable. Mobil'da gorizontal scroll, brend focus-ring, CSS-asosli (`.kz-type-tab`) — yangi motion-token'lardan.
- **Bo'sh + xato holatlari** detal sahifasi bilan bir xil tinch *icon-circle* uslubiga keltirildi (dumaloq muted badge + xabar).

## Book detail (BookDetails)
- Xato va "topilmadi" bitta markazlashgan empty-state'ga birlashtirildi: ikon + xabar + "Barcha kitoblar" CTA — sahifa endi hech qachon boshi berk ko'cha emas (ilgari faqat bir qator matn edi).

## Test
- ESLint ✓ · Prettier ✓ · webpack build **exit 0** (7/7 static) · yangi i18n kalit yo'q (BookTypeChips + Common.viewAll qayta ishlatildi).
- ⚠️ Vizual: dev'da `/community/all` + turlarni almashtirish, bo'sh natija va xato holatlarini 360/768/1440px da ko'rish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)