### PR TITLE
feat(ui): shared EmptyState — unify profile/staff/list/detail empty & error states

### DIFF
--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -26,6 +26,7 @@ import { useRouter, usePathname, Link } from "@/i18n/navigation";
 import Icon from "@/components/Icon";
 import { getContactActions } from "@/utils/contactActions";
 import { mapValidationError } from "@/lib/mapValidationError";
+import EmptyState from "@/components/shared/EmptyState";
 import BookCreateModal from "./BookCreateModal";
 import MoreFromSellerSection from "./MoreFromSellerSection";
 import { useToast } from "./Toast";
@@ -217,48 +218,22 @@ const BookDetails = ({ bookId }) => {
   if (error || !book) {
     const isError = Boolean(error);
     return (
-      <Box
-        sx={{
-          maxWidth: 560,
-          mx: "auto",
-          px: 2,
-          py: { xs: 6, md: 9 },
-          textAlign: "center",
-        }}
-      >
-        <Box
-          sx={{
-            width: 72,
-            height: 72,
-            mx: "auto",
-            mb: 2.5,
-            borderRadius: "50%",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            bgcolor: "var(--surface-muted)",
-            color: "var(--text-muted)",
-          }}
+      <Box sx={{ maxWidth: 560, mx: "auto", px: 2 }}>
+        <EmptyState
+          icon={isError ? "ph ph-warning-circle" : "ph ph-book-open"}
+          title={isError ? error : tBook("notFound")}
         >
-          <Icon
-            className={isError ? "ph ph-warning-circle" : "ph ph-book-open"}
-            style={{ fontSize: 34 }}
-            aria-hidden="true"
-          />
-        </Box>
-        <Typography sx={{ fontSize: 18, fontWeight: 700, color: "var(--text-primary)", mb: 0.75 }}>
-          {isError ? error : tBook("notFound")}
-        </Typography>
-        <Button
-          component={Link}
-          href="/community/all"
-          variant="contained"
-          disableElevation
-          startIcon={<Icon className="ph ph-books" />}
-          sx={{ mt: 1.5, textTransform: "none", fontWeight: 700, borderRadius: 2 }}
-        >
-          {tCommon("viewAll")}
-        </Button>
+          <Button
+            component={Link}
+            href="/community/all"
+            variant="contained"
+            disableElevation
+            startIcon={<Icon className="ph ph-books" />}
+            sx={{ textTransform: "none", fontWeight: 700, borderRadius: 2 }}
+          >
+            {tCommon("viewAll")}
+          </Button>
+        </EmptyState>
       </Box>
     );
   }

--- a/src/components/CommunityBooksPage.jsx
+++ b/src/components/CommunityBooksPage.jsx
@@ -17,6 +17,7 @@ import { getBookCategories, getBookSubcategories } from "@/services/categories";
 import { getRegions } from "@/services/regions";
 import { Link } from "@/i18n/navigation";
 import BookRowGrid from "@/components/shared/BookRowGrid";
+import EmptyState from "@/components/shared/EmptyState";
 import Icon from "@/components/Icon";
 import { mapValidationError } from "@/lib/mapValidationError";
 
@@ -379,34 +380,11 @@ const CommunityBooksPage = ({ type = "all" }) => {
         </Stack>
 
         {error ? (
-          <Box
-            sx={{
-              py: { xs: 6, md: 8 },
-              px: 2,
-              textAlign: "center",
-              border: "1px solid var(--border-subtle)",
-              borderRadius: "var(--radius-lg, 16px)",
-              bgcolor: "var(--surface-card)",
-            }}
-          >
-            <Box
-              sx={{
-                width: 64,
-                height: 64,
-                mx: "auto",
-                mb: 2,
-                borderRadius: "50%",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                bgcolor: "var(--surface-muted)",
-                color: "var(--text-muted)",
-              }}
-            >
-              <Icon className="ph ph-warning-circle" style={{ fontSize: 30 }} aria-hidden="true" />
-            </Box>
-            <Typography sx={{ color: "var(--text-secondary)" }}>{error}</Typography>
-          </Box>
+          <EmptyState
+            icon="ph ph-warning-circle"
+            title={error}
+            sx={{ border: "1px solid var(--border-subtle)", bgcolor: "var(--surface-card)" }}
+          />
         ) : (
           <>
             <BookRowGrid
@@ -414,37 +392,7 @@ const CommunityBooksPage = ({ type = "all" }) => {
               loading={loading}
               skeletonCount={6}
               showTypeBadge={showTypeBadge}
-              emptyState={
-                <Box
-                  sx={{
-                    py: { xs: 6, md: 8 },
-                    px: 2,
-                    textAlign: "center",
-                    border: "1px dashed var(--border-subtle)",
-                    borderRadius: "var(--radius-lg, 16px)",
-                  }}
-                >
-                  <Box
-                    sx={{
-                      width: 64,
-                      height: 64,
-                      mx: "auto",
-                      mb: 2,
-                      borderRadius: "50%",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      bgcolor: "var(--surface-muted)",
-                      color: "var(--text-muted)",
-                    }}
-                  >
-                    <Icon className="ph ph-book-open" style={{ fontSize: 30 }} aria-hidden="true" />
-                  </Box>
-                  <Typography sx={{ fontWeight: 600, color: "var(--text-primary)" }}>
-                    {t("noResults")}
-                  </Typography>
-                </Box>
-              }
+              emptyState={<EmptyState icon="ph ph-book-open" title={t("noResults")} dashed />}
             />
 
             {/* Infinite-scroll trigger + spinner. The sentinel sits ~400px

--- a/src/components/profile/ProfileStaffTab.jsx
+++ b/src/components/profile/ProfileStaffTab.jsx
@@ -19,6 +19,7 @@ import { useToast } from "@/components/Toast";
 import { listStaff, addStaff, removeStaff } from "@/services/shopStaff";
 import { mapValidationError } from "@/lib/mapValidationError";
 import Icon from "@/components/Icon";
+import EmptyState from "@/components/shared/EmptyState";
 
 const ProfileStaffTab = ({ shops = [] }) => {
   const t = useTranslations("ProfileDashboard");
@@ -132,25 +133,11 @@ const ProfileStaffTab = ({ shops = [] }) => {
   if (!shops.length) {
     return (
       <Box sx={{ p: { xs: 2, md: 4 } }}>
-        <Box
-          sx={{
-            textAlign: "center",
-            py: 6,
-            color: "var(--text-muted)",
-          }}
-        >
-          <Icon
-            className="ph ph-storefront"
-            style={{ fontSize: 48, display: "inline-block", marginBottom: 12 }}
-            aria-hidden="true"
-          />
-          <Typography sx={{ fontWeight: 600, color: "var(--text-secondary)" }}>
-            {tStaff("noShopsTitle")}
-          </Typography>
-          <Typography variant="body2" sx={{ mt: 1 }}>
-            {tStaff("noShopsSubtitle")}
-          </Typography>
-        </Box>
+        <EmptyState
+          icon="ph ph-storefront"
+          title={tStaff("noShopsTitle")}
+          description={tStaff("noShopsSubtitle")}
+        />
       </Box>
     );
   }
@@ -262,17 +249,12 @@ const ProfileStaffTab = ({ shops = [] }) => {
       )}
 
       {!loading && !error && staff.length === 0 && (
-        <Box sx={{ py: 4, textAlign: "center", color: "var(--text-muted)" }}>
-          <Icon
-            className="ph ph-users-three"
-            style={{ fontSize: 40, display: "inline-block", marginBottom: 8 }}
-            aria-hidden="true"
-          />
-          <Typography>{tStaff("emptyTitle")}</Typography>
-          <Typography variant="body2" sx={{ mt: 0.5 }}>
-            {tStaff("emptySubtitle")}
-          </Typography>
-        </Box>
+        <EmptyState
+          icon="ph ph-users-three"
+          title={tStaff("emptyTitle")}
+          description={tStaff("emptySubtitle")}
+          sx={{ py: { xs: 4, md: 5 } }}
+        />
       )}
 
       {!loading && !error && staff.length > 0 && (

--- a/src/components/profile/ProfileTabs.jsx
+++ b/src/components/profile/ProfileTabs.jsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import BookCard from "@/components/BookCard";
 import BookGrid from "@/components/shared/BookGrid";
 import Icon from "@/components/Icon";
+import EmptyState from "@/components/shared/EmptyState";
 import ProfileStaffTab from "./ProfileStaffTab";
 
 const ProfileTabs = ({
@@ -25,11 +26,7 @@ const ProfileTabs = ({
   const tProfile = useTranslations("ProfileDashboard");
 
   const renderEmptyState = (iconClass, title, subtitle) => (
-    <div className="text-center py-60">
-      <Icon className={`${iconClass} text-gray-300 text-5xl mb-16`}></Icon>
-      <h5 className="text-gray-500 mb-0">{title}</h5>
-      <p className="text-gray-400 text-sm mt-8">{subtitle}</p>
-    </div>
+    <EmptyState icon={iconClass} title={title} description={subtitle} dashed />
   );
 
   const renderBooksTab = () => (

--- a/src/components/shared/EmptyState.jsx
+++ b/src/components/shared/EmptyState.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import Icon from "@/components/Icon";
+
+/**
+ * Shared empty / error placeholder — one calm, consistent pattern across the
+ * book detail, browse list, profile tabs and wishlist. A round muted icon
+ * badge, a title, an optional description, and optional actions (children,
+ * e.g. a CTA button) rendered in a centered row.
+ *
+ * Props:
+ * - icon        Phosphor glyph class (default "ph ph-book-open")
+ * - title       primary line (string|node)
+ * - description optional secondary line
+ * - dashed      dashed border frame (used for "no results" inside a grid)
+ * - children    optional actions row (buttons/links)
+ * - sx          extra styles merged onto the wrapper
+ */
+const EmptyState = ({
+  icon = "ph ph-book-open",
+  title,
+  description,
+  dashed = false,
+  children,
+  sx,
+}) => (
+  <Box
+    sx={{
+      py: { xs: 6, md: 8 },
+      px: 2,
+      textAlign: "center",
+      border: dashed ? "1px dashed var(--border-subtle)" : "none",
+      borderRadius: "var(--radius-lg, 16px)",
+      ...sx,
+    }}
+  >
+    <Box
+      sx={{
+        width: 64,
+        height: 64,
+        mx: "auto",
+        mb: 2,
+        borderRadius: "50%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        bgcolor: "var(--surface-muted)",
+        color: "var(--text-muted)",
+      }}
+    >
+      <Icon className={icon} style={{ fontSize: 30 }} aria-hidden="true" />
+    </Box>
+    {title ? (
+      <Typography sx={{ fontWeight: 600, color: "var(--text-primary)", mb: description ? 0.5 : 0 }}>
+        {title}
+      </Typography>
+    ) : null}
+    {description ? (
+      <Typography sx={{ fontSize: 14, color: "var(--text-muted)" }}>{description}</Typography>
+    ) : null}
+    {children ? (
+      <Box sx={{ mt: 2.5, display: "flex", justifyContent: "center", gap: 1.5, flexWrap: "wrap" }}>
+        {children}
+      </Box>
+    ) : null}
+  </Box>
+);
+
+export default EmptyState;


### PR DESCRIPTION
Full-project UX/UI polish'ning **3-iteratsiyasi** — profil & wishlist, hamda DRY tozalash.

## Yangi umumiy komponent
- **`shared/EmptyState.jsx`** — dumaloq muted ikon-badge + sarlavha + ixtiyoriy tavsif + ixtiyoriy amal qatori. Butun app uchun bitta tinch, izchil bo'sh/xato namunasi; token-asosli, dark-mode xavfsiz.

## Qayerda qo'llandi
- **ProfileTabs** — kitoblar + arxiv bo'sh holatlari (ilgari Bootstrap `text-gray-*` inline edi, dark-mode'da yomon ko'rinardi).
- **ProfileStaffTab** — "xodim yo'q" + "do'kon yo'q" holatlari.
- **CommunityBooksPage** — "natija yo'q" + xato (2-bosqichdagi inline icon-circle'lar o'rniga).
- **BookDetails** — topilmadi/xato (yangi amal-sloti orqali "Barcha kitoblar" CTA saqlanди).

Wishlist'ning o'ziga xos gradientli bo'sh paneli allaqachon chiroyli — o'zgartirilmadi.

## Test
- ESLint ✓ · Prettier ✓ · webpack compile ✓ · yangi i18n kalit yo'q.
- ⚠️ Vizual: dev'da profil (kitob/arxiv/xodim bo'sh holatlar), `/community/all` bo'sh natija, book-detail topilmadi holatini 360/768/1440px da ko'rish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)