### PR TITLE
feat(ui): polish login screen — token-driven card + premium code field

### DIFF
--- a/src/app/[locale]/globals.scss
+++ b/src/app/[locale]/globals.scss
@@ -851,6 +851,41 @@ body.body-no-scroll {
   }
 }
 
+// ─── Login OTP code field (AuthLogin) ───────────────────────────────────────
+// A single paste-friendly code input (autocomplete="one-time-code") styled as a
+// premium, centered, monospaced field with a brand focus ring. Single field
+// (not segmented boxes) keeps paste/autofill robust and the markup simple.
+.kz-otp-input {
+  width: 100%;
+  text-align: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 1.7rem;
+  font-weight: 600;
+  letter-spacing: 0.5em;
+  // Extra left padding offsets the trailing letter-spacing so the digits sit
+  // optically centered.
+  padding: 14px 12px 14px 22px;
+  color: var(--text-primary);
+  background-color: var(--surface-card);
+  border: 1.5px solid var(--border-subtle);
+  border-radius: var(--radius-md, 12px);
+  transition:
+    border-color var(--dur-fast, 0.15s) var(--ease-out, ease),
+    box-shadow var(--dur-fast, 0.15s) var(--ease-out, ease);
+
+  &::placeholder {
+    color: var(--text-muted);
+    letter-spacing: 0.5em;
+  }
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+    border-color: var(--main-600, hsl(148, 59%, 39%));
+    box-shadow: var(--ring, 0 0 0 3px hsl(148 59% 39% / 0.35));
+  }
+}
+
 // ─── ProfileTabs (sticky nav, horizontal scroll on mobile) ───────────────────
 // Only the nav row sticks; content scrolls past it. `position: sticky` on a
 // child of an `overflow: hidden` ancestor is broken, so the wrapper must not

--- a/src/components/AuthLogin.jsx
+++ b/src/components/AuthLogin.jsx
@@ -100,8 +100,8 @@ const AuthLogin = () => {
                 onSubmit={handleSubmit}
                 style={{
                   background: "var(--surface-card)",
-                  borderRadius: 20,
-                  boxShadow: "0 12px 40px rgba(0,0,0,0.10)",
+                  borderRadius: "var(--radius-xl, 22px)",
+                  boxShadow: "var(--shadow-pop, 0 14px 36px rgba(15,23,42,0.14))",
                   border: "1px solid var(--border-subtle)",
                   padding: "32px 26px",
                 }}
@@ -151,7 +151,7 @@ const AuthLogin = () => {
                     fontWeight: 700,
                     fontSize: "0.98rem",
                     padding: "13px 20px",
-                    borderRadius: 12,
+                    borderRadius: "var(--radius-md, 12px)",
                     textDecoration: "none",
                     boxShadow: "0 8px 20px rgba(0,136,204,0.30)",
                   }}
@@ -192,15 +192,8 @@ const AuthLogin = () => {
                   value={code}
                   onChange={handleChange}
                   maxLength={CODE_LENGTH}
-                  className="common-input"
+                  className="kz-otp-input"
                   aria-label={tAuth("codeLabel")}
-                  style={{
-                    textAlign: "center",
-                    fontSize: "1.7rem",
-                    letterSpacing: "0.55em",
-                    padding: "14px 12px 14px 18px",
-                    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
-                  }}
                   aria-describedby="otp-hint"
                 />
                 <small


### PR DESCRIPTION
Full-project UX/UI polish'ning **4-iteratsiyasi** — auth (login).

Login eng ko'p ko'riladigan va ixcham auth ekrani; forma modallari (BookCreateModal, SellerRegistration, ProfileEdit) allaqachon yaxshi qurilgan MUI wizard'lar (FieldError + mapValidationError), shuning uchun bu o'tish login ekraniga qaratildi va og'ir wizard'larga tegmaydi (regressiya xavfini oldini olish).

## O'zgarishlar (AuthLogin)
- Karta endi dizayn-tizim **tokenlari** (`--radius-xl`, `--shadow-pop`) bilan; tugmalar `--radius-md`.
- OTP kod maydoni alohida **`.kz-otp-input`** klassiga ko'chirildi: markazlashgan monospace raqamlar, aniq brend **focus-ring** (`--ring`), token radius va theme'ga mos ranglar — inline-styled `.common-input` o'rniga. Bitta paste-friendly maydon bo'lib qoldi (`autocomplete="one-time-code"`), markup soddalashdi.

Hech qanday oqim/xulq o'zgarishi yo'q, yangi i18n kalit yo'q.

## Test
- ESLint ✓ · Prettier ✓ · webpack build **exit 0 (7/7 static)**.
- ⚠️ Vizual: dev'da `/login` ni 360/768/1440px da ko'rish — karta, kod maydoni focus holati, light/dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)