### PR TITLE
feat(ui): cohesive MUI theme — rounder inputs/dialogs so all form modals match

### DIFF
--- a/src/components/MaterialThemeProvider.jsx
+++ b/src/components/MaterialThemeProvider.jsx
@@ -48,11 +48,27 @@ const buildTheme = (mode) =>
             background: { default: "#f4f5f7", paper: "#ffffff" },
           }),
     },
+    // Rounder default geometry so MUI inputs/selects in the form modals match
+    // the app's rounded aesthetic (cards 16, pills 999) instead of MUI's sharp
+    // 4px. Affects every OutlinedInput/TextField/Select at once.
+    shape: { borderRadius: 10 },
     typography: baseTypography,
     components: {
       MuiButton: {
         styleOverrides: {
-          root: { textTransform: "none", borderRadius: 8 },
+          root: { textTransform: "none", borderRadius: 10, fontWeight: 600 },
+        },
+      },
+      // Dialogs that don't set their own PaperProps still get a soft, rounded
+      // surface (the big form modals override this with full-screen-on-mobile).
+      MuiDialog: {
+        styleOverrides: {
+          paper: { borderRadius: 16 },
+        },
+      },
+      MuiChip: {
+        styleOverrides: {
+          root: { fontWeight: 600 },
         },
       },
       MuiMenu: {


### PR DESCRIPTION
**6-iteratsiya (formalar).** Katta, konversiyaga kritik forma modallarini (BookCreateModal 1364 qator, SellerRegistration, ProfileEdit) jonli vizual QA'siz qayta qurmaslik uchun — ularni **dizayn-tizim qatlami** orqali sayqalladim: umumiy MUI theme'ni sozlab, har bir dialog/input/select/tugma bir vaqtda kohez'iv bo'ladi.

## MaterialThemeProvider
- **`shape.borderRadius: 10`** — MUI'ning standart 4px input/select'lari app'ning yumaloq kartalari (16) va pill'lariga nisbatan o'tkir edi; 10 hammasini tenglashtiradi.
- **MuiButton**: radius 10 + fontWeight 600.
- **MuiDialog**: standart paper radius 16 (katta modallar mobil'da to'liq-ekranni o'z PaperProps'i bilan override qiladi).
- **MuiChip**: fontWeight 600.

Faqat theme — modal logikasi/markup'iga tegilmadi, shuning uchun oqim regressiyasi yo'q.

## Test
- ESLint ✓ · Prettier ✓ · webpack build **exit 0 (7/7)**.
- ⚠️ Vizual: dev'da kitob qo'shish / profil tahrirlash modallari, input'lar radiusi, light/dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)