### PR TITLE
fix(ui): scope input radius to inputs (not global shape) + option-card hover

### DIFF
--- a/src/components/BookCreateModal.jsx
+++ b/src/components/BookCreateModal.jsx
@@ -95,6 +95,7 @@ const CardSelect = ({ options, value, onChange, getLabel, getCaption }) => (
             cursor: "pointer",
             textAlign: "left",
             transition: "border-color 0.15s ease, background-color 0.15s ease",
+            "&:hover": selected ? undefined : { borderColor: "primary.light" },
           }}
         >
           <Box

--- a/src/components/MaterialThemeProvider.jsx
+++ b/src/components/MaterialThemeProvider.jsx
@@ -48,15 +48,22 @@ const buildTheme = (mode) =>
             background: { default: "#f4f5f7", paper: "#ffffff" },
           }),
     },
-    // Rounder default geometry so MUI inputs/selects in the form modals match
-    // the app's rounded aesthetic (cards 16, pills 999) instead of MUI's sharp
-    // 4px. Affects every OutlinedInput/TextField/Select at once.
-    shape: { borderRadius: 10 },
+    // NOTE: do NOT set `shape.borderRadius` here — in MUI it multiplies every
+    // numeric `borderRadius` in `sx` app-wide (e.g. `borderRadius: 3` → 3×),
+    // which over-rounds dialogs/cards. Round inputs explicitly instead (below).
     typography: baseTypography,
     components: {
       MuiButton: {
         styleOverrides: {
           root: { textTransform: "none", borderRadius: 10, fontWeight: 600 },
+        },
+      },
+      // Round inputs/selects to match the app's rounded aesthetic (the original
+      // MUI 4px looked sharp next to the rounded cards) — px value, so it does
+      // NOT cascade into the `sx` borderRadius multiplier.
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: { borderRadius: 10 },
         },
       },
       // Dialogs that don't set their own PaperProps still get a soft, rounded


### PR DESCRIPTION
**Tuzatish** — oldingi theme polish'iga (#82). `shape.borderRadius: 10` noto'g'ri lever edi: MUI'da bu qiymat butun app bo'ylab har bir numeric `sx` `borderRadius`'ni **ko'paytiradi**, shuning uchun dialog/kartalardagi `borderRadius: 3` 12px → 30px sakrab, ko'p sirtlarni ortiqcha yumaloqladi.

- `shape.borderRadius` override olib tashlandi → barcha `sx` borderRadius qiymatlari asl o'lchamiga qaytdi.
- Input'lar `MuiOutlinedInput` orqali aniq 10px yumaloqlandi (asl maqsad, ko'paytiruvchi nojo'ya ta'sirisiz).
- BookCreateModal CardSelect: tanlanmagan variant kartochkalarida nozik hover.

Build (7/7) + lint yashil (useMemo ogohlantirishi oldindan mavjud).

⚠️ dev'da: input'lar yumaloq qoladi, lekin dialog/kartalar asl (ortiqcha yumaloq emas) holatига qaytadi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)