### PR TITLE
feat(ui): roomier profile book grid (360px) + cleaner book-modal header

### DIFF
--- a/src/components/BookCreateModal.jsx
+++ b/src/components/BookCreateModal.jsx
@@ -1026,18 +1026,47 @@ const BookCreateModal = ({
           sx={{
             display: "flex",
             alignItems: "center",
-            justifyContent: "space-between",
+            gap: 1,
             px: { xs: 2, md: 3 },
             py: 1.5,
           }}
         >
-          <Typography sx={{ fontSize: 16, fontWeight: 700 }}>
+          <Typography
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: 16,
+              fontWeight: 700,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
             {editBook ? t("editBook") : t("addBook")}
           </Typography>
-          <Typography variant="caption" sx={{ color: "var(--text-muted)" }}>
-            {step + 1} / {steps.length}
-          </Typography>
-          <IconButton onClick={onClose} aria-label={tCommon("cancel")} size="small">
+          {/* Step pill — compact, right-aligned, never crowds the title on a
+              360px screen (was a bare counter floating in the header centre). */}
+          <Box
+            component="span"
+            sx={{
+              flexShrink: 0,
+              fontSize: 12,
+              fontWeight: 700,
+              color: "var(--text-secondary)",
+              bgcolor: "var(--surface-muted)",
+              px: 1,
+              py: 0.25,
+              borderRadius: 999,
+            }}
+          >
+            {step + 1}/{steps.length}
+          </Box>
+          <IconButton
+            onClick={onClose}
+            aria-label={tCommon("cancel")}
+            size="small"
+            sx={{ flexShrink: 0 }}
+          >
             <Icon className="ph ph-x" style={{ fontSize: 18 }} aria-hidden="true" />
           </IconButton>
         </Box>

--- a/src/components/profile/ProfileTabs.jsx
+++ b/src/components/profile/ProfileTabs.jsx
@@ -30,7 +30,7 @@ const ProfileTabs = ({
   );
 
   const renderBooksTab = () => (
-    <div className="p-3 p-md-4">
+    <div className="px-2 px-md-4 py-3 py-md-4">
       <div className="profile-tabs__head">
         <div className="profile-tabs__head-title">
           <h3 className="text-xl text-md-2xl fw-bold text-gray-900 mb-0">{tProfile("myBooks")}</h3>
@@ -67,7 +67,7 @@ const ProfileTabs = ({
   );
 
   const renderArchiveTab = () => (
-    <div className="p-3 p-md-4">
+    <div className="px-2 px-md-4 py-3 py-md-4">
       <div className="profile-tabs__head profile-tabs__head--single">
         <div className="profile-tabs__head-title">
           <h3 className="text-xl text-md-2xl fw-bold text-gray-900 mb-0">


### PR DESCRIPTION
Jonli QA'dan ikkita 360px tuzatish:

- **Profil kitoblar/arxiv gridi** wishlist ("liked")ga nisbatan zich edi: ikkalasi ham bir xil BookGrid+BookCard ishlatadi, lekin profil uni chegarali tab-karta ichida 16px padding bilan o'rardi, wishlist esa frameless 12px. Profil tab kontentining gorizontal padding'ini mobil'da kamaytirdim (`px-2 / px-md-4`) → kartochkalar wishlist kabi keng. Umumiy grid'ga tegilmadi, wishlist o'zgarmadi.
- **BookCreateModal header**: qadam hisoblagichi `space-between` orqali markazda suzib, 360px'da sarlavhani siqardi. Endi sarlavha qatorni egallaydi (ellipsis), ixcham qadam-pill + close o'ngda.

Build (7/7) + lint yashil (lockShop ogohlantirishi oldindan mavjud).

⚠️ **dev'da 360px**: Profil → kitoblar (kengroq), Kitob qo'shish modal header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)