### PR TITLE
fix(ui): widen profile so books grid matches wishlist (desktop density)

### DIFF
--- a/src/components/ProfileDashboard.jsx
+++ b/src/components/ProfileDashboard.jsx
@@ -607,70 +607,85 @@ const ProfileDashboard = () => {
     >
       <Box
         sx={{
-          maxWidth: 720,
+          // App-standard content width (matches community + wishlist at 1240).
+          // Was 720, which crammed the books grid — col-md-4/col-xl-3 keys off
+          // the viewport, not this box, so a wide desktop forced 4 tiny ~160px
+          // cards into a 720 column. 1240 gives the grid wishlist-parity.
+          maxWidth: 1240,
           mx: "auto",
           px: { xs: 2, md: 3 },
         }}
       >
         <Stack spacing={{ xs: 2, md: 2.5 }}>
-          <ProfileHero
-            user={userData}
-            stats={{
-              books: userBooks.length,
-              archive: archivedBooks.length,
-              shops: userShops.length,
-            }}
-            avatarUploading={avatarUploading}
-            onAvatarChange={handleAvatarChange}
-            onEditClick={handleEditProfile}
-            onShareClick={handleShareProfile}
-            locationLine={locationChip}
-            roleLabel={roleLabel}
-          />
+          {/* Header cluster stays a comfortable centered column so the hero,
+              story bar and contact card don't stretch thin on wide screens;
+              only the books grid below spans the full width (wishlist-parity). */}
+          <Box sx={{ width: "100%", maxWidth: 760, mx: "auto" }}>
+            <Stack spacing={{ xs: 2, md: 2.5 }}>
+              <ProfileHero
+                user={userData}
+                stats={{
+                  books: userBooks.length,
+                  archive: archivedBooks.length,
+                  shops: userShops.length,
+                }}
+                avatarUploading={avatarUploading}
+                onAvatarChange={handleAvatarChange}
+                onEditClick={handleEditProfile}
+                onShareClick={handleShareProfile}
+                locationLine={locationChip}
+                roleLabel={roleLabel}
+              />
 
-          <ProfileStoryBar books={userBooks} shops={userShops} onAddBookClick={handleCreateBook} />
+              <ProfileStoryBar
+                books={userBooks}
+                shops={userShops}
+                onAddBookClick={handleCreateBook}
+              />
 
-          {userShops.length > 0 && (
-            <Stack direction="row" sx={{ justifyContent: "center", flexWrap: "wrap", gap: 1 }}>
-              <Button
-                variant="contained"
-                onClick={() => setShowStoryModal(true)}
-                startIcon={
-                  <Icon
-                    className="ph ph-paper-plane-tilt"
-                    style={{ fontSize: 18 }}
-                    aria-hidden="true"
-                  />
-                }
-                sx={{ textTransform: "none", fontWeight: 600, borderRadius: 5, px: 3 }}
-              >
-                {tProfile("addStory")}
-              </Button>
-              {/* Quick link to the owner's shop page, where the edit (pencil)
+              {userShops.length > 0 && (
+                <Stack direction="row" sx={{ justifyContent: "center", flexWrap: "wrap", gap: 1 }}>
+                  <Button
+                    variant="contained"
+                    onClick={() => setShowStoryModal(true)}
+                    startIcon={
+                      <Icon
+                        className="ph ph-paper-plane-tilt"
+                        style={{ fontSize: 18 }}
+                        aria-hidden="true"
+                      />
+                    }
+                    sx={{ textTransform: "none", fontWeight: 600, borderRadius: 5, px: 3 }}
+                  >
+                    {tProfile("addStory")}
+                  </Button>
+                  {/* Quick link to the owner's shop page, where the edit (pencil)
                   button lives — the editor was previously only reachable from
                   the public shop page, which owners couldn't find. */}
-              {userShops.map((shop) => (
-                <Button
-                  key={shop.id}
-                  component={Link}
-                  href={`/shops/${shop.id}`}
-                  variant="outlined"
-                  startIcon={
-                    <Icon
-                      className="ph ph-storefront"
-                      style={{ fontSize: 18 }}
-                      aria-hidden="true"
-                    />
-                  }
-                  sx={{ textTransform: "none", fontWeight: 600, borderRadius: 5, px: 3 }}
-                >
-                  {userShops.length > 1 ? shop.name : tShopLoc("myShop")}
-                </Button>
-              ))}
-            </Stack>
-          )}
+                  {userShops.map((shop) => (
+                    <Button
+                      key={shop.id}
+                      component={Link}
+                      href={`/shops/${shop.id}`}
+                      variant="outlined"
+                      startIcon={
+                        <Icon
+                          className="ph ph-storefront"
+                          style={{ fontSize: 18 }}
+                          aria-hidden="true"
+                        />
+                      }
+                      sx={{ textTransform: "none", fontWeight: 600, borderRadius: 5, px: 3 }}
+                    >
+                      {userShops.length > 1 ? shop.name : tShopLoc("myShop")}
+                    </Button>
+                  ))}
+                </Stack>
+              )}
 
-          <ProfileInfoList user={userData} locationLine={locationFull} />
+              <ProfileInfoList user={userData} locationLine={locationFull} />
+            </Stack>
+          </Box>
 
           <ProfileTabs
             activeTab={activeTab}


### PR DESCRIPTION
**Sabab (desktop'da zich va kichik):** butun profil `maxWidth 720` bilan cheklangan edi, lekin `BookGrid` ustunlari (`col-md-4`/`col-xl-3`) **viewport**'ga qarab ishlaydi, konteynerga emas — shuning uchun keng desktop'da 4 ta kartochka 720px ustunga tiqilardi (~160px har biri). Wishlist ("liked") 1240 konteynerda → ~290px kartochkalar.

- Profil kontenti **1240**'ga kengaytirildi (app standarti, community + wishlist bilan bir xil) → kitoblar/arxiv gridi wishlist-parligida.
- Header klasteri (hero, story bar, kontakt karta) **760** markazlashgan ustunda qoldirildi — keng ekranda cho'zilib ketmasligi uchun; faqat tablar/grid to'liq kenglikni egallaydi.

Build (7/7) + lint yashil.

⚠️ **dev'da desktop**: Profil → Kitoblarim — kartochkalar endi liked'dagidek katta. Header markazda ixcham qoladi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)