### PR TITLE
feat(ui): coherent full-width profile — banner hero + contact grid

### DIFF
--- a/src/components/ProfileDashboard.jsx
+++ b/src/components/ProfileDashboard.jsx
@@ -617,75 +617,64 @@ const ProfileDashboard = () => {
         }}
       >
         <Stack spacing={{ xs: 2, md: 2.5 }}>
-          {/* Header cluster stays a comfortable centered column so the hero,
-              story bar and contact card don't stretch thin on wide screens;
-              only the books grid below spans the full width (wishlist-parity). */}
-          <Box sx={{ width: "100%", maxWidth: 760, mx: "auto" }}>
-            <Stack spacing={{ xs: 2, md: 2.5 }}>
-              <ProfileHero
-                user={userData}
-                stats={{
-                  books: userBooks.length,
-                  archive: archivedBooks.length,
-                  shops: userShops.length,
-                }}
-                avatarUploading={avatarUploading}
-                onAvatarChange={handleAvatarChange}
-                onEditClick={handleEditProfile}
-                onShareClick={handleShareProfile}
-                locationLine={locationChip}
-                roleLabel={roleLabel}
-              />
+          <ProfileHero
+            user={userData}
+            stats={{
+              books: userBooks.length,
+              archive: archivedBooks.length,
+              shops: userShops.length,
+            }}
+            avatarUploading={avatarUploading}
+            onAvatarChange={handleAvatarChange}
+            onEditClick={handleEditProfile}
+            onShareClick={handleShareProfile}
+            locationLine={locationChip}
+            roleLabel={roleLabel}
+          />
 
-              <ProfileStoryBar
-                books={userBooks}
-                shops={userShops}
-                onAddBookClick={handleCreateBook}
-              />
+          <ProfileStoryBar books={userBooks} shops={userShops} onAddBookClick={handleCreateBook} />
 
-              {userShops.length > 0 && (
-                <Stack direction="row" sx={{ justifyContent: "center", flexWrap: "wrap", gap: 1 }}>
-                  <Button
-                    variant="contained"
-                    onClick={() => setShowStoryModal(true)}
-                    startIcon={
-                      <Icon
-                        className="ph ph-paper-plane-tilt"
-                        style={{ fontSize: 18 }}
-                        aria-hidden="true"
-                      />
-                    }
-                    sx={{ textTransform: "none", fontWeight: 600, borderRadius: 5, px: 3 }}
-                  >
-                    {tProfile("addStory")}
-                  </Button>
-                  {/* Quick link to the owner's shop page, where the edit (pencil)
+          {userShops.length > 0 && (
+            <Stack direction="row" sx={{ justifyContent: "center", flexWrap: "wrap", gap: 1 }}>
+              <Button
+                variant="contained"
+                onClick={() => setShowStoryModal(true)}
+                startIcon={
+                  <Icon
+                    className="ph ph-paper-plane-tilt"
+                    style={{ fontSize: 18 }}
+                    aria-hidden="true"
+                  />
+                }
+                sx={{ textTransform: "none", fontWeight: 600, borderRadius: 5, px: 3 }}
+              >
+                {tProfile("addStory")}
+              </Button>
+              {/* Quick link to the owner's shop page, where the edit (pencil)
                   button lives — the editor was previously only reachable from
                   the public shop page, which owners couldn't find. */}
-                  {userShops.map((shop) => (
-                    <Button
-                      key={shop.id}
-                      component={Link}
-                      href={`/shops/${shop.id}`}
-                      variant="outlined"
-                      startIcon={
-                        <Icon
-                          className="ph ph-storefront"
-                          style={{ fontSize: 18 }}
-                          aria-hidden="true"
-                        />
-                      }
-                      sx={{ textTransform: "none", fontWeight: 600, borderRadius: 5, px: 3 }}
-                    >
-                      {userShops.length > 1 ? shop.name : tShopLoc("myShop")}
-                    </Button>
-                  ))}
-                </Stack>
-              )}
-
-              <ProfileInfoList user={userData} locationLine={locationFull} />
+              {userShops.map((shop) => (
+                <Button
+                  key={shop.id}
+                  component={Link}
+                  href={`/shops/${shop.id}`}
+                  variant="outlined"
+                  startIcon={
+                    <Icon
+                      className="ph ph-storefront"
+                      style={{ fontSize: 18 }}
+                      aria-hidden="true"
+                    />
+                  }
+                  sx={{ textTransform: "none", fontWeight: 600, borderRadius: 5, px: 3 }}
+                >
+                  {userShops.length > 1 ? shop.name : tShopLoc("myShop")}
+                </Button>
+              ))}
             </Stack>
-          </Box>
+          )}
+
+          <ProfileInfoList user={userData} locationLine={locationFull} />
 
           <ProfileTabs
             activeTab={activeTab}

--- a/src/components/profile/ProfileHero.jsx
+++ b/src/components/profile/ProfileHero.jsx
@@ -59,136 +59,152 @@ const ProfileHero = ({
         boxShadow: "var(--shadow-card)",
       }}
     >
-      <Stack spacing={2} sx={{ alignItems: "center" }}>
-        <Box sx={{ position: "relative", display: "inline-block" }}>
-          <Avatar
-            src={user?.picture || undefined}
-            alt={fullName}
-            sx={{
-              width: { xs: 100, md: 140 },
-              height: { xs: 100, md: 140 },
-              fontSize: { xs: 36, md: 48 },
-              bgcolor: "primary.light",
-              boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
-            }}
-          >
-            {initial}
-          </Avatar>
-          <IconButton
-            onClick={() => fileInputRef.current?.click()}
-            disabled={avatarUploading}
-            aria-label={t("cameraButton")}
-            sx={{
-              position: "absolute",
-              bottom: 0,
-              right: 0,
-              width: 36,
-              height: 36,
-              bgcolor: "primary.main",
-              color: "#fff",
-              boxShadow: "0 2px 6px rgba(0,0,0,0.15)",
-              "&:hover": { bgcolor: "primary.dark" },
-              "&.Mui-disabled": { bgcolor: "grey.400", color: "#fff" },
-            }}
-          >
-            {avatarUploading ? (
-              <CircularProgress size={18} sx={{ color: "#fff" }} />
-            ) : (
-              <Icon className="ph ph-camera" style={{ fontSize: 18 }} />
-            )}
-          </IconButton>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            hidden
-            onChange={handleFileSelect}
-          />
-        </Box>
-
-        <Box sx={{ textAlign: "center", width: "100%" }}>
-          <Typography
-            component="h1"
-            sx={{
-              fontSize: { xs: 20, md: 24 },
-              fontWeight: 700,
-              color: "text.primary",
-              lineHeight: 1.2,
-            }}
-          >
-            {fullName}
-          </Typography>
-          {phone && (
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-              {phone}
-            </Typography>
-          )}
-          {(locationLine || roleLabel) && (
-            <Stack
-              direction="row"
-              spacing={1}
-              sx={{ justifyContent: "center", flexWrap: "wrap", mt: 1, rowGap: 1 }}
-            >
-              {locationLine && (
-                <Chip
-                  size="small"
-                  icon={
-                    <Icon className="ph ph-map-pin" style={{ fontSize: 14, color: "inherit" }} />
-                  }
-                  label={locationLine}
-                  sx={{
-                    bgcolor: "var(--surface-muted)",
-                    color: "var(--text-secondary)",
-                    height: 24,
-                  }}
-                />
-              )}
-              {roleLabel && (
-                <Chip
-                  size="small"
-                  label={roleLabel}
-                  color="primary"
-                  variant="outlined"
-                  sx={{ height: 24 }}
-                />
-              )}
-            </Stack>
-          )}
-        </Box>
-
+      <Stack spacing={{ xs: 2, md: 2.5 }}>
+        {/* Top row: a horizontal banner on desktop (avatar · identity · actions),
+            a centered stack on mobile. */}
         <Stack
-          direction="row"
-          spacing={1.5}
-          sx={{ flexWrap: "wrap", justifyContent: "center", rowGap: 1 }}
+          direction={{ xs: "column", md: "row" }}
+          spacing={{ xs: 2, md: 3 }}
+          sx={{ alignItems: "center" }}
         >
-          <Button
-            variant="contained"
-            onClick={onEditClick}
-            startIcon={<Icon className="ph ph-pencil-simple" style={{ fontSize: 16 }} />}
-            sx={{
-              borderRadius: 2,
-              textTransform: "none",
-              px: 3,
-              fontWeight: 600,
-            }}
+          <Box sx={{ position: "relative", flexShrink: 0 }}>
+            <Avatar
+              src={user?.picture || undefined}
+              alt={fullName}
+              sx={{
+                width: { xs: 100, md: 140 },
+                height: { xs: 100, md: 140 },
+                fontSize: { xs: 36, md: 48 },
+                bgcolor: "primary.light",
+                boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
+              }}
+            >
+              {initial}
+            </Avatar>
+            <IconButton
+              onClick={() => fileInputRef.current?.click()}
+              disabled={avatarUploading}
+              aria-label={t("cameraButton")}
+              sx={{
+                position: "absolute",
+                bottom: 0,
+                right: 0,
+                width: 36,
+                height: 36,
+                bgcolor: "primary.main",
+                color: "#fff",
+                boxShadow: "0 2px 6px rgba(0,0,0,0.15)",
+                "&:hover": { bgcolor: "primary.dark" },
+                "&.Mui-disabled": { bgcolor: "grey.400", color: "#fff" },
+              }}
+            >
+              {avatarUploading ? (
+                <CircularProgress size={18} sx={{ color: "#fff" }} />
+              ) : (
+                <Icon className="ph ph-camera" style={{ fontSize: 18 }} />
+              )}
+            </IconButton>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              hidden
+              onChange={handleFileSelect}
+            />
+          </Box>
+
+          <Box
+            sx={{ flex: 1, minWidth: 0, width: "100%", textAlign: { xs: "center", md: "left" } }}
           >
-            {t("editProfile")}
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={onShareClick}
-            startIcon={<Icon className="ph ph-share-network" style={{ fontSize: 16 }} />}
-            sx={{
-              borderRadius: 2,
-              textTransform: "none",
-              px: 3,
-              fontWeight: 600,
-            }}
+            <Typography
+              component="h1"
+              sx={{
+                fontSize: { xs: 20, md: 24 },
+                fontWeight: 700,
+                color: "text.primary",
+                lineHeight: 1.2,
+              }}
+            >
+              {fullName}
+            </Typography>
+            {phone && (
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                {phone}
+              </Typography>
+            )}
+            {(locationLine || roleLabel) && (
+              <Stack
+                direction="row"
+                spacing={1}
+                sx={{
+                  justifyContent: { xs: "center", md: "flex-start" },
+                  flexWrap: "wrap",
+                  mt: 1,
+                  rowGap: 1,
+                }}
+              >
+                {locationLine && (
+                  <Chip
+                    size="small"
+                    icon={
+                      <Icon className="ph ph-map-pin" style={{ fontSize: 14, color: "inherit" }} />
+                    }
+                    label={locationLine}
+                    sx={{
+                      bgcolor: "var(--surface-muted)",
+                      color: "var(--text-secondary)",
+                      height: 24,
+                    }}
+                  />
+                )}
+                {roleLabel && (
+                  <Chip
+                    size="small"
+                    label={roleLabel}
+                    color="primary"
+                    variant="outlined"
+                    sx={{ height: 24 }}
+                  />
+                )}
+              </Stack>
+            )}
+          </Box>
+
+          <Stack
+            direction="row"
+            spacing={1.5}
+            sx={{ flexWrap: "wrap", justifyContent: "center", rowGap: 1 }}
           >
-            {t("share")}
-          </Button>
+            <Button
+              variant="contained"
+              onClick={onEditClick}
+              startIcon={<Icon className="ph ph-pencil-simple" style={{ fontSize: 16 }} />}
+              sx={{
+                borderRadius: 2,
+                textTransform: "none",
+                px: 3,
+                fontWeight: 600,
+              }}
+            >
+              {t("editProfile")}
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={onShareClick}
+              startIcon={<Icon className="ph ph-share-network" style={{ fontSize: 16 }} />}
+              sx={{
+                borderRadius: 2,
+                textTransform: "none",
+                px: 3,
+                fontWeight: 600,
+              }}
+            >
+              {t("share")}
+            </Button>
+          </Stack>
         </Stack>
 
+        {/* Stats span the full banner width below the identity row. */}
         <Stack
           direction="row"
           divider={

--- a/src/components/profile/ProfileInfoList.jsx
+++ b/src/components/profile/ProfileInfoList.jsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { useTranslations } from "next-intl";
-import { Box, Stack, Typography, Divider } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import Icon from "@/components/Icon";
 
 const Row = ({ icon, label, value, href }) => {
@@ -151,11 +151,21 @@ const ProfileInfoList = ({ user, locationLine, locale }) => {
       >
         {t("infoTitle")}
       </Typography>
-      <Stack divider={<Divider flexItem />}>
+      {/* Contact items flow into as many columns as the card width allows, so
+          the card fills a full-width profile instead of being a sparse single
+          column. One column on phones. */}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", sm: "repeat(auto-fit, minmax(220px, 1fr))" },
+          columnGap: 3,
+          rowGap: 0.5,
+        }}
+      >
         {rows.map((row) => (
           <Row key={row.key} icon={row.icon} label={row.label} value={row.value} href={row.href} />
         ))}
-      </Stack>
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
**Designer tuzatish.** Oldingi urinish 760 markazlashgan header'ni 1240 grid ustida qoldirdi — mos kelmas, tasodifiy ko'rinardi ("tepasi pastiga mos emas"). Asl sabab: `ProfileHero` (markazlashgan-vertikal) va `ProfileInfoList` (vertikal ro'yxat) **tor ustun** uchun qurilgan — keng kartada orol bo'lib ko'rinardi.

Butun profilni **bitta izchil to'liq-kenglik** sahifaga aylantirdim (1240, community/wishlist feed'lari bilan bir xil) va tor-uchun qurilgan qismlarni kengni to'ldiradigan qilib qayta dizayn qildim:
- **ProfileDashboard**: yagona 1240 konteyner; har bo'lim bir xil chetlarda (tepa = past). Kitoblar gridi wishlist-parligida (4 × ~290px).
- **ProfileHero**: desktop'da gorizontal banner (avatar · identity · amallar bir qatorda, statistika pastda to'liq kenglik); mobil'da markazlashgan-stacked qoladi.
- **ProfileInfoList**: kontakt elementlari auto-fit grid'ga oqadi (keng'da ko'p ustun, telefonda bitta) — siyrak vertikal ro'yxat o'rniga.

Build (7/7) + lint yashil.

⚠️ **dev'da desktop + 360px**: Profil — header endi to'liq-kenglik banner, kontakt ko'p-ustunli, kitoblar liked'dek; hammasi bir xil chetda (mos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)