### PR TITLE
feat(ui): app-like redesign — shell, search, footer, header & design language

### DIFF
--- a/public/assets/sass/abstracts/_variable.scss
+++ b/public/assets/sass/abstracts/_variable.scss
@@ -214,10 +214,13 @@ $font-sizes: (
   --display-one: clamp(2.5rem, -0.0733rem + 6.3692vw, 7.5rem); // Min:40px - Max:120px
   /* Font Size End */
 
-  /* template main color */
-  --main-h: 148;
-  --main-s: 59%;
-  --main-l: 39%;
+  /* template main color — deepened/de-noised for a premium feel (Phase 3
+     design language). Kept in the same green family; the whole 50–900 scale
+     and every legacy green derive from these. Mirrored in MUI theme
+     (MaterialThemeProvider BRAND) and the --brand tokens (globals.scss). */
+  --main-h: 150;
+  --main-s: 55%;
+  --main-l: 35%;
   --main: var(--main-h) var(--main-s) var(--main-l);
 
   /* template main color */

--- a/src/app/[locale]/globals.scss
+++ b/src/app/[locale]/globals.scss
@@ -66,6 +66,10 @@
   --brand-strong: hsl(148, 59%, 31%);
   --brand-soft: hsla(148, 59%, 39%, 0.12);
 
+  // App-shell desktop side rail width (content is offset by this on ≥ lg).
+  --rail-w: 84px;
+  --rail-w-xl: 92px;
+
   --border-subtle: rgba(15, 23, 42, 0.08);
   --border-strong: rgba(15, 23, 42, 0.16);
 
@@ -162,6 +166,20 @@ body {
   body {
     --bottom-nav-h: 60px;
     padding-bottom: calc(var(--bottom-nav-h) + env(safe-area-inset-bottom, 0px));
+  }
+}
+
+// App-shell side rail (desktop ≥ lg) is fixed on the left; offset the whole
+// document (sticky header + content both shift since the header is in flow)
+// so nothing sits under the rail.
+@media (min-width: 992px) {
+  body {
+    padding-left: var(--rail-w, 84px);
+  }
+}
+@media (min-width: 1280px) {
+  body {
+    padding-left: var(--rail-w-xl, 92px);
   }
 }
 

--- a/src/app/[locale]/globals.scss
+++ b/src/app/[locale]/globals.scss
@@ -60,6 +60,12 @@
   --text-muted: #64748b;
   --text-on-brand: #ffffff;
 
+  // Brand accent (Kitobzor green — mirrors the MUI theme `primary.main`).
+  // Single source for app-shell active states, CTAs, brand chrome.
+  --brand: hsl(148, 59%, 39%);
+  --brand-strong: hsl(148, 59%, 31%);
+  --brand-soft: hsla(148, 59%, 39%, 0.12);
+
   --border-subtle: rgba(15, 23, 42, 0.08);
   --border-strong: rgba(15, 23, 42, 0.16);
 
@@ -109,6 +115,11 @@
   --text-secondary: #cbd5e1;
   --text-muted: #94a3b8;
 
+  // Brand reads brighter on dark surfaces so active states stay legible.
+  --brand: hsl(148, 59%, 52%);
+  --brand-strong: hsl(148, 59%, 60%);
+  --brand-soft: hsla(148, 59%, 52%, 0.18);
+
   // Global headings use `color: hsl(var(--heading-color))` (_typography.scss).
   // Light value (#121535) was dark-on-dark in dark mode (QA B-3). Flip to a
   // light HSL triplet so every h1–h6 on a dark surface is legible.
@@ -142,6 +153,16 @@ body,
 body {
   background-color: var(--surface-page);
   color: var(--text-primary);
+}
+
+// App-shell bottom tab bar (mobile/tablet < lg) is fixed over the content;
+// reserve space so the last row / footer isn't hidden behind it. Desktop
+// (>= lg) uses the side rail and needs no bottom inset.
+@media (max-width: 991.98px) {
+  body {
+    --bottom-nav-h: 60px;
+    padding-bottom: calc(var(--bottom-nav-h) + env(safe-area-inset-bottom, 0px));
+  }
 }
 
 // In dark mode, many Bootstrap-styled cards/sections in legacy markup still

--- a/src/app/[locale]/globals.scss
+++ b/src/app/[locale]/globals.scss
@@ -50,9 +50,12 @@
 
 // ─── Theme tokens (light = default, dark = `[data-theme="dark"]`) ────────────
 :root {
-  --surface-page: #f4f5f7;
+  // Ultra-clean minimal (Phase 3): an airier near-white page so white cards
+  // read as content on a calm canvas, delineated by hairline borders + very
+  // light shadows rather than heavy elevation.
+  --surface-page: #f7f8fa;
   --surface-card: #ffffff;
-  --surface-muted: #f8fafc;
+  --surface-muted: #f6f8fb;
   --surface-elevated: #ffffff;
 
   --text-primary: #0f172a;
@@ -60,11 +63,11 @@
   --text-muted: #64748b;
   --text-on-brand: #ffffff;
 
-  // Brand accent (Kitobzor green — mirrors the MUI theme `primary.main`).
+  // Brand accent (Kitobzor green — mirrors _variable.scss --main + MUI primary).
   // Single source for app-shell active states, CTAs, brand chrome.
-  --brand: hsl(148, 59%, 39%);
-  --brand-strong: hsl(148, 59%, 31%);
-  --brand-soft: hsla(148, 59%, 39%, 0.12);
+  --brand: hsl(150, 55%, 35%);
+  --brand-strong: hsl(150, 55%, 27%);
+  --brand-soft: hsla(150, 55%, 35%, 0.12);
 
   // App-shell desktop side rail width (content is offset by this on ≥ lg).
   --rail-w: 84px;
@@ -73,8 +76,8 @@
   --border-subtle: rgba(15, 23, 42, 0.08);
   --border-strong: rgba(15, 23, 42, 0.16);
 
-  --shadow-card: 0 2px 6px rgba(15, 23, 42, 0.06);
-  --shadow-elevated: 0 4px 12px rgba(15, 23, 42, 0.1);
+  --shadow-card: 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-elevated: 0 4px 10px rgba(15, 23, 42, 0.07);
 
   // ── Design-system scales (minimalist / professional) ──────────────────────
   // Opt-in tokens so surfaces share one rhythm. Existing components keep their
@@ -87,13 +90,14 @@
   --radius-xl: 22px;
   --radius-pill: 999px;
 
-  // Elevation (soft, low-contrast — depth without heaviness)
-  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04), 0 1px 3px rgba(15, 23, 42, 0.06);
-  --shadow-hover: 0 6px 18px rgba(15, 23, 42, 0.09);
-  --shadow-pop: 0 14px 36px rgba(15, 23, 42, 0.14);
+  // Elevation (ultra-minimal — hairline borders do most of the delineation;
+  // shadows are a whisper, lifting only on interaction).
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-hover: 0 4px 14px rgba(15, 23, 42, 0.07);
+  --shadow-pop: 0 12px 30px rgba(15, 23, 42, 0.1);
 
   // Focus ring (keyboard a11y) — brand-tinted, consistent everywhere
-  --ring: 0 0 0 3px hsl(148 59% 39% / 0.35);
+  --ring: 0 0 0 3px hsl(150 55% 35% / 0.35);
 
   // Motion — one easing/duration language across the app
   --dur-fast: 0.15s;
@@ -120,9 +124,9 @@
   --text-muted: #94a3b8;
 
   // Brand reads brighter on dark surfaces so active states stay legible.
-  --brand: hsl(148, 59%, 52%);
-  --brand-strong: hsl(148, 59%, 60%);
-  --brand-soft: hsla(148, 59%, 52%, 0.18);
+  --brand: hsl(150, 55%, 52%);
+  --brand-strong: hsl(150, 55%, 62%);
+  --brand-soft: hsla(150, 55%, 52%, 0.18);
 
   // Global headings use `color: hsl(var(--heading-color))` (_typography.scss).
   // Light value (#121535) was dark-on-dark in dark mode (QA B-3). Flip to a
@@ -137,7 +141,7 @@
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
   --shadow-hover: 0 6px 18px rgba(0, 0, 0, 0.5);
   --shadow-pop: 0 14px 36px rgba(0, 0, 0, 0.6);
-  --ring: 0 0 0 3px hsl(148 59% 49% / 0.45);
+  --ring: 0 0 0 3px hsl(150 55% 49% / 0.45);
 
   color-scheme: dark;
 }

--- a/src/app/[locale]/layout.jsx
+++ b/src/app/[locale]/layout.jsx
@@ -68,6 +68,11 @@ const PostBookMount = dynamic(() => import("@/components/PostBookMount"), {
 const BottomTabBar = dynamic(() => import("@/components/shell/BottomTabBar"), {
   loading: () => null,
 });
+// App-shell desktop side rail — the persistent left navigation on ≥ lg.
+// Content is offset by `--rail-w` via globals.scss.
+const SideRail = dynamic(() => import("@/components/shell/SideRail"), {
+  loading: () => null,
+});
 // Global share sheet — mounted at the layout root so any component can
 // dispatch `share-sheet:open` and get a Telegram/WhatsApp/SMS picker.
 const ShareSheetMount = dynamic(() => import("@/components/ShareSheetMount"), {
@@ -194,6 +199,7 @@ export default async function RootLayout({ children, params }) {
                 <PostBookMount />
                 <ShareSheetMount />
                 <BottomTabBar />
+                <SideRail />
               </ProtectedRoute>
             </MaterialThemeProvider>
           </NextIntlClientProvider>

--- a/src/app/[locale]/layout.jsx
+++ b/src/app/[locale]/layout.jsx
@@ -62,6 +62,12 @@ const PostBookFab = dynamic(() => import("@/components/PostBookFab"), {
 const PostBookMount = dynamic(() => import("@/components/PostBookMount"), {
   loading: () => null,
 });
+// App-shell bottom tab bar — the primary navigation on mobile/tablet (< lg).
+// Lives in the layout so it persists across page transitions; hides itself on
+// auth pages and on desktop (where the side rail takes over).
+const BottomTabBar = dynamic(() => import("@/components/shell/BottomTabBar"), {
+  loading: () => null,
+});
 // Global share sheet — mounted at the layout root so any component can
 // dispatch `share-sheet:open` and get a Telegram/WhatsApp/SMS picker.
 const ShareSheetMount = dynamic(() => import("@/components/ShareSheetMount"), {
@@ -187,6 +193,7 @@ export default async function RootLayout({ children, params }) {
                 <PostBookFab />
                 <PostBookMount />
                 <ShareSheetMount />
+                <BottomTabBar />
               </ProtectedRoute>
             </MaterialThemeProvider>
           </NextIntlClientProvider>

--- a/src/components/BottomFooter.jsx
+++ b/src/components/BottomFooter.jsx
@@ -1,16 +1,37 @@
+"use client";
 import React from "react";
 import { useTranslations } from "next-intl";
 
+/**
+ * Slim legal/copyright strip rendered directly under <FooterOne />. Token-driven
+ * styled-jsx (migrated off the Bootstrap `bg-color-one` utility) so it shares
+ * the footer's surface and reads as one cohesive block.
+ */
 const BottomFooter = () => {
   const tBF = useTranslations("BottomFooter");
   return (
-    <div className="bottom-footer bg-color-one py-8">
-      <div className="container container-lg">
-        <div className="bottom-footer__inner flex-between flex-wrap gap-16 py-16">
-          <p className="bottom-footer__text ">{tBF("copyright")}</p>
-          <div className="flex-align gap-8 flex-wrap"></div>
-        </div>
-      </div>
+    <div className="kz-bottom-footer">
+      <p className="kz-bottom-footer__text">{tBF("copyright")}</p>
+
+      <style jsx>{`
+        .kz-bottom-footer {
+          background: var(--surface-card);
+          border-top: 1px solid var(--border-subtle);
+        }
+        .kz-bottom-footer__text {
+          max-width: var(--container-max, 1240px);
+          margin: 0 auto;
+          padding: 16px 20px;
+          text-align: center;
+          font-size: 13px;
+          color: var(--text-muted);
+        }
+        @media (min-width: 768px) {
+          .kz-bottom-footer__text {
+            padding: 18px 24px;
+          }
+        }
+      `}</style>
     </div>
   );
 };

--- a/src/components/FooterOne.jsx
+++ b/src/components/FooterOne.jsx
@@ -9,19 +9,23 @@ import { getFacebookUrl, getInstagramUrl, getTelegramChannelUrl } from "@/config
 import Icon from "@/components/Icon";
 
 /**
- * Footer — three balanced columns:
+ * Footer — app-like, minimal, token-driven (Phase 2 of the redesign).
  *
- *   1) Brand + Telegram-bot CTA      (left, the primary conversion path)
- *   2) Site & Help links             (centre, two short stacks)
- *   3) Account / Social              (right, auth-aware profile entry)
+ * Migrated off the Bootstrap grid + scattered inline styles to a self-scoped
+ * styled-jsx CSS grid (per CLAUDE.md §1.3 migration order: HeaderOne → Footer).
+ * The old 1920px `body-bottom-bg` <img> — which relied on `overflow-x:hidden`
+ * to avoid horizontal scroll (audit P2) — is gone; the footer is now a clean
+ * surface that pairs with the app shell (bottom tab bar / side rail).
  *
- * Removed (template leftovers):
- *   - Redundant phone/email/address (Contact page already covers these)
- *   - App-store buttons (no native app yet)
- *   - Twitter / LinkedIn / Pinterest (we don't run those accounts)
+ * Columns:
+ *   1) Brand + blurb + socials   (left)
+ *   2) Saytda links              (site nav)
+ *   3) Yordam links              (help / info)
+ *   4) Account CTA               (auth-aware, right)
  *
- * The whole footer sits over a soft pattern background. Surfaces use the
- * `--surface-*` CSS vars so dark mode renders without extra rules.
+ * next-intl <Link> is a custom component, so link rules are written with
+ * :global() under the scoped `.kz-footer` host (raw <a>/<button> are scoped
+ * automatically).
  */
 const FooterOne = () => {
   const tF = useTranslations("Footer");
@@ -29,339 +33,333 @@ const FooterOne = () => {
   const { isAuthenticated: isAuth } = useAuth();
 
   return (
-    <footer
-      className="footer"
-      style={{
-        position: "relative",
-        backgroundColor: "var(--surface-page)",
-        borderTop: "1px solid var(--border-subtle)",
-        paddingTop: "48px",
-        paddingBottom: "32px",
-      }}
-    >
-      <img
-        src="/assets/images/bg/kitobzor-footer-bg.png"
-        alt=""
-        aria-hidden="true"
-        className="body-bottom-bg"
-      />
+    <footer className="kz-footer">
+      <div className="kz-footer__inner">
+        <div className="kz-footer__grid">
+          {/* ─── Brand + blurb + socials ─────────────────────────────── */}
+          <div className="kz-footer__brand">
+            <Link href="/" aria-label="Kitobzor" className="kz-footer__brand-link">
+              <span className="kz-footer__brand-mark" aria-hidden="true">
+                <Image
+                  src="/assets/images/logo/kitobzor-logo.png"
+                  alt=""
+                  width={44}
+                  height={44}
+                  style={{ objectFit: "cover" }}
+                />
+              </span>
+              <span className="kz-footer__brand-name">kitobzor</span>
+            </Link>
+            <p className="kz-footer__blurb">{tF("about.blurb")}</p>
 
-      <div className="container container-lg position-relative">
-        <div className="row gy-5">
-          {/* ─── Brand + Telegram bot CTA ───────────────────────────── */}
-          <div className="col-lg-4 col-md-6">
-            <div className="footer-item">
-              <div className="footer-item__logo mb-16">
-                <Link
-                  href="/"
-                  aria-label="Kitobzor"
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 12,
-                    textDecoration: "none",
-                    color: "var(--text-primary)",
-                  }}
+            <p className="kz-footer__social-label">{tF("social.followUs")}</p>
+            <ul className="kz-footer__socials">
+              <li>
+                <a
+                  href={getTelegramChannelUrl()}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Telegram"
+                  className="kz-footer__social"
                 >
-                  <span
-                    aria-hidden="true"
-                    style={{
-                      width: 44,
-                      height: 44,
-                      borderRadius: "50%",
-                      overflow: "hidden",
-                      backgroundColor: "#e7f1ea",
-                      boxShadow: "0 6px 14px rgba(34, 197, 94, 0.18)",
-                      display: "inline-flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      flexShrink: 0,
-                    }}
-                  >
-                    <Image
-                      src="/assets/images/logo/kitobzor-logo.png"
-                      alt=""
-                      width={44}
-                      height={44}
-                      style={{ objectFit: "cover" }}
-                    />
-                  </span>
-                  <span
-                    style={{
-                      fontSize: 22,
-                      fontWeight: 800,
-                      letterSpacing: "-0.02em",
-                      lineHeight: 1,
-                    }}
-                  >
-                    kitobzor
-                  </span>
-                </Link>
-              </div>
-              <p className="mb-16" style={{ color: "var(--text-secondary)", fontSize: 14 }}>
-                {tF("about.blurb")}
-              </p>
-              {/* Bot deep-link intentionally removed from the footer — the
-                  login page is the single canonical entry to the bot, so
-                  there's no need to advertise it elsewhere on the site. */}
-            </div>
-          </div>
-
-          {/* ─── Site nav ────────────────────────────────────────────── */}
-          <div className="col-lg-2 col-md-3 col-6">
-            <h6
-              className="mb-16"
-              style={{
-                fontSize: 13,
-                fontWeight: 700,
-                textTransform: "uppercase",
-                color: "var(--text-muted)",
-                letterSpacing: 0.5,
-              }}
-            >
-              {tF("site.title")}
-            </h6>
-            <ul className="footer-menu list-unstyled m-0">
-              <FooterLink href="/" label={tF("site.home")} />
-              <FooterLink href="/shops" label={tF("site.shops")} />
-              <FooterLink href="/community/all" label={tF("site.community")} />
-              <li className="mb-10">
-                <button
-                  type="button"
-                  onClick={openSellerModal}
-                  style={{
-                    fontSize: 14,
-                    color: "var(--text-secondary)",
-                    textDecoration: "none",
-                    transition: "color 0.15s ease",
-                    background: "transparent",
-                    border: "none",
-                    padding: 0,
-                    cursor: "pointer",
-                  }}
-                  className="hover-text-main-600"
+                  <Icon className="ph-fill ph-telegram-logo" aria-hidden="true" />
+                </a>
+              </li>
+              <li>
+                <a
+                  href={getInstagramUrl()}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Instagram"
+                  className="kz-footer__social"
                 >
-                  {tF("site.becomeSeller")}
-                </button>
+                  <Icon className="ph-fill ph-instagram-logo" aria-hidden="true" />
+                </a>
+              </li>
+              <li>
+                <a
+                  href={getFacebookUrl()}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Facebook"
+                  className="kz-footer__social"
+                >
+                  <Icon className="ph-fill ph-facebook-logo" aria-hidden="true" />
+                </a>
               </li>
             </ul>
           </div>
 
+          {/* ─── Site nav ────────────────────────────────────────────── */}
+          <nav className="kz-footer__col" aria-label={tF("site.title")}>
+            <h3 className="kz-footer__heading">{tF("site.title")}</h3>
+            <ul className="kz-footer__menu">
+              <FooterLink href="/" label={tF("site.home")} />
+              <FooterLink href="/shops" label={tF("site.shops")} />
+              <FooterLink href="/community/all" label={tF("site.community")} />
+              <li>
+                <button type="button" onClick={openSellerModal} className="kz-footer__seller-btn">
+                  {tF("site.becomeSeller")}
+                </button>
+              </li>
+            </ul>
+          </nav>
+
           {/* ─── Help / info ─────────────────────────────────────────── */}
-          <div className="col-lg-2 col-md-3 col-6">
-            <h6
-              className="mb-16"
-              style={{
-                fontSize: 13,
-                fontWeight: 700,
-                textTransform: "uppercase",
-                color: "var(--text-muted)",
-                letterSpacing: 0.5,
-              }}
-            >
-              {tF("help.title")}
-            </h6>
-            <ul className="footer-menu list-unstyled m-0">
+          <nav className="kz-footer__col" aria-label={tF("help.title")}>
+            <h3 className="kz-footer__heading">{tF("help.title")}</h3>
+            <ul className="kz-footer__menu">
               <FooterLink href="/about-us" label={tF("help.aboutUs")} />
               <FooterLink href="/contact" label={tF("help.contact")} />
               <FooterLink href="/faq" label={tF("help.faq")} />
               <FooterLink href="/policies" label={tF("help.privacy")} />
             </ul>
-          </div>
+          </nav>
 
-          {/* ─── Account + Social ────────────────────────────────────── */}
-          <div className="col-lg-4 col-md-12">
-            <h6
-              className="mb-16"
-              style={{
-                fontSize: 13,
-                fontWeight: 700,
-                textTransform: "uppercase",
-                color: "var(--text-muted)",
-                letterSpacing: 0.5,
-              }}
-            >
-              {tF("account.title")}
-            </h6>
-
-            <div className="mb-20">
-              {isAuth ? (
-                <Link
-                  href="/account"
-                  className="d-inline-flex align-items-center gap-12 rounded-3 px-16 py-12 w-100"
-                  style={{
-                    backgroundColor: "var(--surface-card)",
-                    border: "1px solid var(--border-subtle)",
-                    color: "var(--text-primary)",
-                    textDecoration: "none",
-                    boxShadow: "var(--shadow-card)",
-                    transition: "transform 0.15s ease",
-                  }}
-                >
-                  <span
-                    className="flex-center rounded-circle flex-shrink-0"
-                    style={{
-                      width: 40,
-                      height: 40,
-                      backgroundColor: "var(--main-50, hsl(148, 59%, 95%))",
-                      color: "var(--main-600, hsl(148, 59%, 39%))",
-                      fontSize: 20,
-                    }}
-                  >
-                    <Icon className="ph-fill ph-user" aria-hidden="true" />
-                  </span>
-                  <span className="d-flex flex-column" style={{ minWidth: 0 }}>
-                    <span style={{ fontSize: 14, fontWeight: 700 }}>
-                      {tF("account.openProfile")}
-                    </span>
-                    <span
-                      style={{
-                        fontSize: 12,
-                        color: "var(--text-muted)",
-                      }}
-                    >
-                      {tF("account.openProfileHint")}
-                    </span>
-                  </span>
-                  <Icon
-                    className="ph ph-caret-right ms-auto"
-                    style={{ fontSize: 18, color: "var(--text-muted)" }}
-                    aria-hidden="true"
-                  />
-                </Link>
-              ) : (
-                <Link
-                  href="/login"
-                  className="d-inline-flex align-items-center gap-12 rounded-3 px-16 py-12 w-100"
-                  style={{
-                    backgroundColor: "var(--surface-card)",
-                    border: "1px solid var(--border-subtle)",
-                    color: "var(--text-primary)",
-                    textDecoration: "none",
-                    boxShadow: "var(--shadow-card)",
-                  }}
-                >
-                  <span
-                    className="flex-center rounded-circle flex-shrink-0"
-                    style={{
-                      width: 40,
-                      height: 40,
-                      backgroundColor: "var(--main-50, hsl(148, 59%, 95%))",
-                      color: "var(--main-600, hsl(148, 59%, 39%))",
-                      fontSize: 20,
-                    }}
-                  >
-                    <Icon className="ph-fill ph-sign-in" aria-hidden="true" />
-                  </span>
-                  <span className="d-flex flex-column" style={{ minWidth: 0 }}>
-                    <span style={{ fontSize: 14, fontWeight: 700 }}>{tHeader("login")}</span>
-                    <span
-                      style={{
-                        fontSize: 12,
-                        color: "var(--text-muted)",
-                      }}
-                    >
-                      {tF("account.loginHint")}
-                    </span>
-                  </span>
-                  <Icon
-                    className="ph ph-caret-right ms-auto"
-                    style={{ fontSize: 18, color: "var(--text-muted)" }}
-                    aria-hidden="true"
-                  />
-                </Link>
-              )}
-            </div>
-
-            <div>
-              <p
-                style={{
-                  fontSize: 12,
-                  color: "var(--text-muted)",
-                  marginBottom: 8,
-                }}
-              >
-                {tF("social.followUs")}
-              </p>
-              <ul className="d-flex gap-12 list-unstyled m-0">
-                <li>
-                  <a
-                    href={getTelegramChannelUrl()}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="Telegram"
-                    className="flex-center rounded-circle"
-                    style={{
-                      width: 40,
-                      height: 40,
-                      backgroundColor: "var(--surface-card)",
-                      border: "1px solid var(--border-subtle)",
-                      color: "var(--main-600, hsl(148, 59%, 39%))",
-                      fontSize: 18,
-                    }}
-                  >
-                    <Icon className="ph-fill ph-telegram-logo" aria-hidden="true" />
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href={getInstagramUrl()}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="Instagram"
-                    className="flex-center rounded-circle"
-                    style={{
-                      width: 40,
-                      height: 40,
-                      backgroundColor: "var(--surface-card)",
-                      border: "1px solid var(--border-subtle)",
-                      color: "var(--main-600, hsl(148, 59%, 39%))",
-                      fontSize: 18,
-                    }}
-                  >
-                    <Icon className="ph-fill ph-instagram-logo" aria-hidden="true" />
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href={getFacebookUrl()}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="Facebook"
-                    className="flex-center rounded-circle"
-                    style={{
-                      width: 40,
-                      height: 40,
-                      backgroundColor: "var(--surface-card)",
-                      border: "1px solid var(--border-subtle)",
-                      color: "var(--main-600, hsl(148, 59%, 39%))",
-                      fontSize: 18,
-                    }}
-                  >
-                    <Icon className="ph-fill ph-facebook-logo" aria-hidden="true" />
-                  </a>
-                </li>
-              </ul>
-            </div>
+          {/* ─── Account CTA (auth-aware) ────────────────────────────── */}
+          <div className="kz-footer__account">
+            <h3 className="kz-footer__heading">{tF("account.title")}</h3>
+            <Link href={isAuth ? "/account" : "/login"} className="kz-footer__account-card">
+              <span className="kz-footer__account-icon" aria-hidden="true">
+                <Icon className={isAuth ? "ph-fill ph-user" : "ph-fill ph-sign-in"} />
+              </span>
+              <span className="kz-footer__account-text">
+                <span className="kz-footer__account-title">
+                  {isAuth ? tF("account.openProfile") : tHeader("login")}
+                </span>
+                <span className="kz-footer__account-hint">
+                  {isAuth ? tF("account.openProfileHint") : tF("account.loginHint")}
+                </span>
+              </span>
+              <Icon className="ph ph-caret-right kz-footer__account-caret" aria-hidden="true" />
+            </Link>
           </div>
         </div>
       </div>
+
+      <style jsx>{`
+        .kz-footer {
+          margin-block-start: auto;
+          background: var(--surface-card);
+          border-top: 1px solid var(--border-subtle);
+        }
+        .kz-footer__inner {
+          max-width: var(--container-max, 1240px);
+          margin: 0 auto;
+          padding: 44px 20px 36px;
+        }
+        @media (min-width: 768px) {
+          .kz-footer__inner {
+            padding: 56px 24px 40px;
+          }
+        }
+
+        .kz-footer__grid {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 32px 24px;
+        }
+        @media (min-width: 768px) {
+          .kz-footer__grid {
+            grid-template-columns: 1.6fr 1fr 1fr;
+          }
+        }
+        @media (min-width: 992px) {
+          .kz-footer__grid {
+            grid-template-columns: 1.7fr 1fr 1fr 1.5fr;
+            gap: 40px;
+          }
+        }
+
+        /* Brand spans the full row on phones (above the two link columns). */
+        .kz-footer__brand {
+          grid-column: 1 / -1;
+        }
+        @media (min-width: 768px) {
+          .kz-footer__brand {
+            grid-column: auto;
+          }
+        }
+
+        .kz-footer :global(.kz-footer__brand-link) {
+          display: inline-flex;
+          align-items: center;
+          gap: 12px;
+          text-decoration: none;
+          color: var(--text-primary);
+        }
+        .kz-footer__brand-mark {
+          width: 44px;
+          height: 44px;
+          border-radius: 50%;
+          overflow: hidden;
+          background: var(--brand-soft);
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          flex-shrink: 0;
+        }
+        .kz-footer__brand-name {
+          font-size: 22px;
+          font-weight: 800;
+          letter-spacing: -0.02em;
+          line-height: 1;
+        }
+        .kz-footer__blurb {
+          margin: 16px 0 20px;
+          max-width: 34ch;
+          color: var(--text-secondary);
+          font-size: 14px;
+          line-height: 1.55;
+        }
+
+        .kz-footer__social-label {
+          margin: 0 0 8px;
+          font-size: 12px;
+          color: var(--text-muted);
+        }
+        .kz-footer__socials {
+          display: flex;
+          gap: 10px;
+          list-style: none;
+          margin: 0;
+          padding: 0;
+        }
+        .kz-footer__social {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 42px;
+          height: 42px;
+          border-radius: 50%;
+          background: var(--surface-muted);
+          border: 1px solid var(--border-subtle);
+          color: var(--text-secondary);
+          font-size: 19px;
+          transition:
+            color var(--dur-fast, 0.15s) var(--ease-out, ease),
+            background-color var(--dur-fast, 0.15s) var(--ease-out, ease),
+            transform var(--dur-fast, 0.15s) var(--ease-out, ease);
+        }
+        .kz-footer__social:hover {
+          color: var(--brand);
+          background: var(--brand-soft);
+          transform: translateY(-2px);
+        }
+        .kz-footer__social:focus-visible {
+          outline: none;
+          box-shadow: var(--ring);
+        }
+
+        .kz-footer__heading {
+          margin: 0 0 16px;
+          font-size: 12px;
+          font-weight: 700;
+          text-transform: uppercase;
+          letter-spacing: 0.06em;
+          color: var(--text-muted);
+        }
+        .kz-footer__menu {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 11px;
+        }
+        .kz-footer :global(.kz-footer__link),
+        .kz-footer__seller-btn {
+          display: inline-block;
+          font-size: 14px;
+          color: var(--text-secondary);
+          text-decoration: none;
+          background: none;
+          border: none;
+          padding: 0;
+          cursor: pointer;
+          transition: color var(--dur-fast, 0.15s) var(--ease-out, ease);
+        }
+        .kz-footer :global(.kz-footer__link:hover),
+        .kz-footer__seller-btn:hover {
+          color: var(--brand);
+        }
+        .kz-footer :global(.kz-footer__link:focus-visible),
+        .kz-footer__seller-btn:focus-visible {
+          outline: none;
+          box-shadow: var(--ring);
+          border-radius: 4px;
+        }
+
+        .kz-footer__account {
+          grid-column: 1 / -1;
+        }
+        @media (min-width: 992px) {
+          .kz-footer__account {
+            grid-column: auto;
+          }
+        }
+        .kz-footer :global(.kz-footer__account-card) {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding: 12px 16px;
+          border-radius: var(--radius-lg, 16px);
+          background: var(--surface-page);
+          border: 1px solid var(--border-subtle);
+          color: var(--text-primary);
+          text-decoration: none;
+          box-shadow: var(--shadow-sm);
+          transition:
+            transform var(--dur-fast, 0.15s) var(--ease-out, ease),
+            box-shadow var(--dur-fast, 0.15s) var(--ease-out, ease);
+        }
+        .kz-footer :global(.kz-footer__account-card:hover) {
+          transform: translateY(-2px);
+          box-shadow: var(--shadow-hover);
+        }
+        .kz-footer :global(.kz-footer__account-card:focus-visible) {
+          outline: none;
+          box-shadow: var(--ring);
+        }
+        .kz-footer__account-icon {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 42px;
+          height: 42px;
+          border-radius: 50%;
+          flex-shrink: 0;
+          background: var(--brand-soft);
+          color: var(--brand);
+          font-size: 21px;
+        }
+        .kz-footer__account-text {
+          display: flex;
+          flex-direction: column;
+          min-width: 0;
+        }
+        .kz-footer__account-title {
+          font-size: 14px;
+          font-weight: 700;
+        }
+        .kz-footer__account-hint {
+          font-size: 12px;
+          color: var(--text-muted);
+        }
+        .kz-footer :global(.kz-footer__account-caret) {
+          margin-left: auto;
+          font-size: 18px;
+          color: var(--text-muted);
+          flex-shrink: 0;
+        }
+      `}</style>
     </footer>
   );
 };
 
 const FooterLink = ({ href, label }) => (
-  <li className="mb-10">
-    <Link
-      href={href}
-      style={{
-        fontSize: 14,
-        color: "var(--text-secondary)",
-        textDecoration: "none",
-        transition: "color 0.15s ease",
-      }}
-      className="hover-text-main-500"
-    >
+  <li>
+    <Link href={href} className="kz-footer__link">
       {label}
     </Link>
   </li>

--- a/src/components/HeaderOne.jsx
+++ b/src/components/HeaderOne.jsx
@@ -505,6 +505,21 @@ const HeaderOne = () => {
           }
         }
 
+        /* Desktop (>= lg): the app-shell side rail owns the brand + primary
+           nav (and the footer owns the secondary links), so the header sheds
+           its logo and hamburger and becomes a slim top utility bar — theme,
+           language, profile — right-aligned via the .kz-header__right auto
+           margin. The drawer close button (also .kz-header__icon-btn, but
+           inside .kz-drawer__head) is unaffected by the child combinator. */
+        @media (min-width: 992px) {
+          :global(.kz-header__logo) {
+            display: none;
+          }
+          .kz-header__inner > .kz-header__icon-btn {
+            display: none;
+          }
+        }
+
         .kz-header__icon-btn {
           width: 36px;
           height: 36px;

--- a/src/components/HeaderOne.jsx
+++ b/src/components/HeaderOne.jsx
@@ -12,6 +12,7 @@ import { openSellerModal } from "@/lib/sellerModal";
 import Icon from "@/components/Icon";
 import ThemeToggle from "./ThemeToggle";
 import LanguageSwitcher from "./LanguageSwitcher";
+import SearchBar from "./shell/SearchBar";
 
 /**
  * Telegram-inspired header.
@@ -158,6 +159,13 @@ const HeaderOne = () => {
             <span className="kz-header__logo-text">kitobzor</span>
           </Link>
 
+          {/* Desktop search — fills the space the logo/hamburger vacate on the
+              app-shell header (≥ lg). Hidden below lg, where it drops to a
+              full-width row under the bar (see kz-header__search-row). */}
+          <div className="kz-header__search-slot">
+            <SearchBar />
+          </div>
+
           {/* Right cluster: theme · language · profile. All three stay
               visible on every breakpoint — settings shouldn't disappear
               on mobile. They simply tighten up below 576px. */}
@@ -241,6 +249,12 @@ const HeaderOne = () => {
               )}
             </div>
           </div>
+        </div>
+
+        {/* Mobile/tablet (< lg) search — a full-width row under the top bar,
+            an app-like pattern that keeps the tight top row uncrowded. */}
+        <div className="kz-header__search-row">
+          <SearchBar />
         </div>
       </header>
 
@@ -516,6 +530,33 @@ const HeaderOne = () => {
             display: none;
           }
           .kz-header__inner > .kz-header__icon-btn {
+            display: none;
+          }
+        }
+
+        /* Global search. Desktop (>= lg): inline in the top bar, filling the
+           space the logo/hamburger vacated, utilities pushed right by the auto
+           margin. Below lg: hidden inline, shown as a full-width row instead. */
+        .kz-header__search-slot {
+          display: none;
+        }
+        @media (min-width: 992px) {
+          .kz-header__search-slot {
+            display: block;
+            flex: 0 1 520px;
+            margin-right: auto;
+          }
+        }
+        .kz-header__search-row {
+          padding: 0 8px 10px;
+        }
+        @media (min-width: 576px) {
+          .kz-header__search-row {
+            padding: 0 12px 12px;
+          }
+        }
+        @media (min-width: 992px) {
+          .kz-header__search-row {
             display: none;
           }
         }

--- a/src/components/MaterialThemeProvider.jsx
+++ b/src/components/MaterialThemeProvider.jsx
@@ -9,10 +9,12 @@ import { getResolvedTheme, subscribeTheme } from "@/lib/theme";
 // NOTE: CssBaseline is intentionally NOT applied — the project depends on
 // Bootstrap 5 for layout/utilities, and CssBaseline would strip those
 // margins/borders/typography.
+// Mirrors _variable.scss --main-h/s/l (150 / 55% / 35%, deepened in Phase 3)
+// and the --brand tokens in globals.scss. Keep all three in sync.
 const BRAND = {
-  main: "hsl(148, 59%, 39%)",
-  light: "hsl(148, 59%, 90%)",
-  dark: "hsl(148, 59%, 31%)",
+  main: "hsl(150, 55%, 35%)",
+  light: "hsl(150, 55%, 90%)",
+  dark: "hsl(150, 55%, 27%)",
   contrastText: "#ffffff",
 };
 
@@ -45,7 +47,8 @@ const buildTheme = (mode) =>
             divider: "rgba(255, 255, 255, 0.12)",
           }
         : {
-            background: { default: "#f4f5f7", paper: "#ffffff" },
+            // Sync with --surface-page (globals.scss) — airier near-white page.
+            background: { default: "#f7f8fa", paper: "#ffffff" },
           }),
     },
     // NOTE: do NOT set `shape.borderRadius` here — in MUI it multiplies every
@@ -82,7 +85,8 @@ const buildTheme = (mode) =>
         styleOverrides: {
           paper: {
             borderRadius: 12,
-            boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+            // Ultra-minimal: lighter, cooler menu elevation.
+            boxShadow: "0 8px 28px rgba(15,23,42,0.10)",
           },
         },
       },

--- a/src/components/PostBookFab.jsx
+++ b/src/components/PostBookFab.jsx
@@ -2,10 +2,8 @@
 
 import React, { useState } from "react";
 import { useTranslations } from "next-intl";
-import { usePathname, useRouter } from "@/i18n/navigation";
-import { isAuthenticated, getUserProfile } from "@/services/auth";
-import { openPostChooser } from "@/lib/postBookModal";
-import { isProfileComplete } from "@/utils/profile";
+import { usePathname } from "@/i18n/navigation";
+import { usePostBookAction } from "@/hooks/usePostBookAction";
 import Icon from "@/components/Icon";
 
 const HIDDEN_SUFFIXES = ["/login", "/auth/auto"];
@@ -27,38 +25,13 @@ const shouldHide = (pathname) => {
  */
 const PostBookFab = () => {
   const t = useTranslations("Fab");
-  const router = useRouter();
   const pathname = usePathname();
   const [hovered, setHovered] = useState(false);
-  const [checking, setChecking] = useState(false);
+  // Shared "post a book" gate (login → profile → chooser). Same hook backs the
+  // bottom tab bar's center "+" so both entry-points behave identically.
+  const { trigger, checking } = usePostBookAction();
 
   if (shouldHide(pathname)) return null;
-
-  const handleClick = async () => {
-    // Step 1 — must be logged in. Carry the current page so login returns here.
-    if (!isAuthenticated()) {
-      const next = encodeURIComponent(pathname || "/");
-      router.push(`/login?next=${next}`);
-      return;
-    }
-    // Step 2 — must have a complete profile (region + district). Check the
-    // live profile, then either route to the profile editor or open the
-    // create modal. If the check itself fails (network), fall through and
-    // let the backend's `profile_incomplete` guard have the final say.
-    setChecking(true);
-    try {
-      const { user } = await getUserProfile();
-      if (!isProfileComplete(user)) {
-        router.push("/account?complete=book");
-        return;
-      }
-      openPostChooser();
-    } catch {
-      openPostChooser();
-    } finally {
-      setChecking(false);
-    }
-  };
 
   return (
     <>
@@ -72,7 +45,7 @@ const PostBookFab = () => {
         </span>
         <button
           type="button"
-          onClick={handleClick}
+          onClick={trigger}
           disabled={checking}
           aria-busy={checking}
           aria-label={t("postBookAria")}
@@ -100,6 +73,14 @@ const PostBookFab = () => {
           gap: 10px;
           /* Safe-area for iOS home-bar */
           margin-bottom: env(safe-area-inset-bottom, 0);
+        }
+
+        /* Mobile/tablet (< lg) post via the bottom tab bar's center "+" — the
+           floating FAB would collide with it, so it's desktop-only now. */
+        @media (max-width: 991.98px) {
+          .post-book-fab__wrap {
+            display: none;
+          }
         }
 
         .post-book-fab__label {

--- a/src/components/shell/BottomTabBar.jsx
+++ b/src/components/shell/BottomTabBar.jsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link, usePathname } from "@/i18n/navigation";
+import Icon from "@/components/Icon";
+import { PRIMARY_NAV, isNavItemActive, isShellHiddenPath } from "@/config/nav";
+import { usePostBookAction } from "@/hooks/usePostBookAction";
+
+/**
+ * App-shell bottom tab bar — the signature "this is an app" surface on
+ * mobile/tablet (< lg). Desktop (≥ lg) hides it and uses the side rail.
+ *
+ * Driven entirely by `PRIMARY_NAV` (src/config/nav.js): link items navigate,
+ * the `center` item is the elevated "post a book" CTA wired to the same gate
+ * as the floating FAB via `usePostBookAction`.
+ */
+export default function BottomTabBar() {
+  const t = useTranslations();
+  const pathname = usePathname();
+  const { trigger, checking } = usePostBookAction();
+
+  if (isShellHiddenPath(pathname)) return null;
+
+  return (
+    <nav className="kz-tabbar" aria-label={t("Nav.primary")}>
+      <ul className="kz-tabbar__list">
+        {PRIMARY_NAV.map((item) => {
+          const label = t(item.labelKey);
+
+          if (item.center) {
+            return (
+              <li key={item.key} className="kz-tabbar__item kz-tabbar__item--center">
+                <button
+                  type="button"
+                  className="kz-tabbar__post"
+                  onClick={trigger}
+                  disabled={checking}
+                  aria-busy={checking}
+                  aria-label={label}
+                >
+                  <Icon className={`ph-bold ph-${item.icon}`} aria-hidden="true" />
+                </button>
+                <span className="kz-tabbar__post-label">{label}</span>
+              </li>
+            );
+          }
+
+          const active = isNavItemActive(item, pathname);
+          return (
+            <li key={item.key} className="kz-tabbar__item">
+              <Link
+                href={item.href}
+                className={`kz-tabbar__link ${active ? "is-active" : ""}`}
+                aria-current={active ? "page" : undefined}
+              >
+                <span className="kz-tabbar__icon" aria-hidden="true">
+                  <Icon className={`${active ? "ph-fill" : "ph"} ph-${item.icon}`} />
+                </span>
+                <span className="kz-tabbar__label">{label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+
+      <style jsx>{`
+        .kz-tabbar {
+          position: fixed;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          z-index: 1090;
+          background: color-mix(in srgb, var(--surface-card) 88%, transparent);
+          backdrop-filter: saturate(180%) blur(12px);
+          -webkit-backdrop-filter: saturate(180%) blur(12px);
+          border-top: 1px solid var(--border-subtle);
+          box-shadow: 0 -6px 20px rgba(15, 23, 42, 0.06);
+          padding-bottom: env(safe-area-inset-bottom, 0px);
+        }
+        /* Desktop uses the side rail instead. */
+        @media (min-width: 992px) {
+          .kz-tabbar {
+            display: none;
+          }
+        }
+
+        .kz-tabbar__list {
+          margin: 0;
+          padding: 0;
+          list-style: none;
+          display: flex;
+          align-items: stretch;
+          height: 60px;
+        }
+        .kz-tabbar__item {
+          flex: 1 1 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        /* next-intl <Link> is a custom component, so styled-jsx can't add its
+           scope class to the rendered <a>. Target it via :global() under the
+           scoped .kz-tabbar host — specificity (0,2,0) also beats the template's
+           global "a { color:#0661e9 }" rule. */
+        .kz-tabbar :global(.kz-tabbar__link) {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          gap: 3px;
+          width: 100%;
+          height: 100%;
+          min-height: 44px;
+          text-decoration: none;
+          color: var(--text-muted);
+          transition: color var(--dur-fast, 0.15s) var(--ease-out, ease);
+          -webkit-tap-highlight-color: transparent;
+        }
+        .kz-tabbar :global(.kz-tabbar__link.is-active) {
+          color: var(--brand);
+        }
+        .kz-tabbar :global(.kz-tabbar__link:focus-visible) {
+          outline: none;
+          box-shadow: var(--ring);
+          border-radius: var(--radius-md, 12px);
+        }
+        .kz-tabbar__icon {
+          display: inline-flex;
+          font-size: 23px;
+          line-height: 1;
+        }
+        .kz-tabbar__label {
+          font-size: 10.5px;
+          font-weight: 600;
+          letter-spacing: 0.01em;
+          line-height: 1;
+          max-width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        /* Center "post" CTA — elevated brand puck overlapping the top edge. */
+        .kz-tabbar__item--center {
+          flex-direction: column;
+          gap: 2px;
+          position: relative;
+        }
+        .kz-tabbar__post {
+          margin-top: -18px;
+          width: 52px;
+          height: 52px;
+          border-radius: 50%;
+          border: 3px solid var(--surface-page);
+          padding: 0;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 26px;
+          color: #fff;
+          cursor: pointer;
+          background: linear-gradient(
+            135deg,
+            hsl(148, 70%, 50%) 0%,
+            hsl(168, 65%, 38%) 60%,
+            hsl(188, 70%, 42%) 100%
+          );
+          box-shadow:
+            0 8px 20px rgba(34, 197, 94, 0.4),
+            0 2px 6px rgba(0, 0, 0, 0.15);
+          transition:
+            transform var(--dur-fast, 0.15s) var(--ease-out, ease),
+            box-shadow var(--dur-fast, 0.15s) var(--ease-out, ease);
+        }
+        .kz-tabbar__post:active {
+          transform: scale(0.93);
+        }
+        .kz-tabbar__post:disabled {
+          opacity: 0.6;
+          cursor: default;
+        }
+        .kz-tabbar__post:focus-visible {
+          outline: 3px solid hsla(148, 70%, 45%, 0.55);
+          outline-offset: 2px;
+        }
+        .kz-tabbar__post-label {
+          font-size: 10.5px;
+          font-weight: 600;
+          line-height: 1;
+          color: var(--text-muted);
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .kz-tabbar__link,
+          .kz-tabbar__post {
+            transition: none;
+          }
+        }
+      `}</style>
+    </nav>
+  );
+}

--- a/src/components/shell/SearchBar.jsx
+++ b/src/components/shell/SearchBar.jsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
+import Icon from "@/components/Icon";
+
+/**
+ * App-shell global search. Submitting routes to the community book list with a
+ * `?search=` query — which CommunityBooksPage already seeds its filter state
+ * from (src/components/CommunityBooksPage.jsx) and forwards to the books API as
+ * `q`, so search works end-to-end without a dedicated results page.
+ *
+ * Self-contained (owns its router) so any shell surface can drop it in. Width
+ * is controlled by the parent slot; the form fills it.
+ */
+export default function SearchBar({ className = "" }) {
+  const t = useTranslations("Header");
+  const router = useRouter();
+  const [q, setQ] = useState("");
+
+  const submit = (e) => {
+    e.preventDefault();
+    const term = q.trim();
+    router.push(term ? `/community/all?search=${encodeURIComponent(term)}` : "/community/all");
+  };
+
+  return (
+    <form className={`kz-search ${className}`} role="search" onSubmit={submit}>
+      <span className="kz-search__icon" aria-hidden="true">
+        <Icon className="ph ph-magnifying-glass" />
+      </span>
+      <input
+        type="search"
+        className="kz-search__input"
+        placeholder={t("searchPlaceholder")}
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        aria-label={t("searchPlaceholder")}
+        enterKeyHint="search"
+      />
+
+      <style jsx>{`
+        .kz-search {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          width: 100%;
+          height: 42px;
+          padding: 0 14px;
+          background: var(--surface-muted);
+          border: 1px solid var(--border-subtle);
+          border-radius: var(--radius-pill, 999px);
+          transition:
+            border-color var(--dur-fast, 0.15s) var(--ease-out, ease),
+            box-shadow var(--dur-fast, 0.15s) var(--ease-out, ease),
+            background-color var(--dur-fast, 0.15s) var(--ease-out, ease);
+        }
+        .kz-search:focus-within {
+          background: var(--surface-card);
+          border-color: var(--brand);
+          box-shadow: var(--ring);
+        }
+        .kz-search__icon {
+          display: inline-flex;
+          align-items: center;
+          font-size: 19px;
+          color: var(--text-muted);
+          flex-shrink: 0;
+        }
+        .kz-search__input {
+          flex: 1;
+          min-width: 0;
+          height: 100%;
+          border: none;
+          outline: none;
+          background: transparent;
+          color: var(--text-primary);
+          font-size: 14px;
+        }
+        .kz-search__input::placeholder {
+          color: var(--text-muted);
+        }
+        /* Hide the native search "clear" affordance — the styling is
+           inconsistent across browsers and clashes with the pill. */
+        .kz-search__input::-webkit-search-decoration,
+        .kz-search__input::-webkit-search-cancel-button {
+          -webkit-appearance: none;
+          appearance: none;
+        }
+      `}</style>
+    </form>
+  );
+}

--- a/src/components/shell/SideRail.jsx
+++ b/src/components/shell/SideRail.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link, usePathname } from "@/i18n/navigation";
 import Icon from "@/components/Icon";
@@ -23,6 +24,11 @@ export default function SideRail() {
 
   return (
     <aside className="kz-rail" aria-label={t("Nav.primary")}>
+      <Link href="/" className="kz-rail__brand" aria-label="Kitobzor">
+        <span className="kz-rail__brand-mark" aria-hidden="true">
+          <Image src="/assets/images/logo/kitobzor-logo.png" alt="" width={40} height={40} />
+        </span>
+      </Link>
       <ul className="kz-rail__list">
         {RAIL_NAV.map((item) => {
           const active = isNavItemActive(item, pathname);
@@ -53,8 +59,6 @@ export default function SideRail() {
           z-index: 95;
           background: var(--surface-card);
           border-right: 1px solid var(--border-subtle);
-          /* Clear the top header band so the first item sits below it. */
-          padding-top: 76px;
           display: none;
           overflow-y: auto;
           overscroll-behavior: contain;
@@ -64,6 +68,33 @@ export default function SideRail() {
           .kz-rail {
             display: block;
           }
+        }
+
+        /* Brand sits at the very top, aligned to the header band height — on
+           desktop the header sheds its own logo, so this is THE brand mark. */
+        .kz-rail :global(.kz-rail__brand) {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: 64px;
+          border-bottom: 1px solid var(--border-subtle);
+          text-decoration: none;
+        }
+        .kz-rail__brand-mark {
+          width: 40px;
+          height: 40px;
+          border-radius: 50%;
+          overflow: hidden;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          background: var(--brand-soft);
+          box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+        }
+        .kz-rail__brand-mark :global(img) {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
         }
 
         .kz-rail__list {

--- a/src/components/shell/SideRail.jsx
+++ b/src/components/shell/SideRail.jsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link, usePathname } from "@/i18n/navigation";
+import Icon from "@/components/Icon";
+import { RAIL_NAV, isNavItemActive, isShellHiddenPath } from "@/config/nav";
+
+/**
+ * App-shell desktop side rail — the persistent left navigation on ≥ lg
+ * (the bottom tab bar takes over below lg). Driven by `RAIL_NAV`
+ * (src/config/nav.js), which carries a couple more destinations than the
+ * 5-slot mobile bar (Shops gets its own entry).
+ *
+ * Pure navigation: the brand/logo stays in the top header and posting a book
+ * stays on the floating FAB, so the rail introduces no duplicate affordances.
+ * Content is offset by `--rail-w` via a body padding rule in globals.scss.
+ */
+export default function SideRail() {
+  const t = useTranslations();
+  const pathname = usePathname();
+
+  if (isShellHiddenPath(pathname)) return null;
+
+  return (
+    <aside className="kz-rail" aria-label={t("Nav.primary")}>
+      <ul className="kz-rail__list">
+        {RAIL_NAV.map((item) => {
+          const active = isNavItemActive(item, pathname);
+          return (
+            <li key={item.key} className="kz-rail__item">
+              <Link
+                href={item.href}
+                className={`kz-rail__link ${active ? "is-active" : ""}`}
+                aria-current={active ? "page" : undefined}
+              >
+                <span className="kz-rail__icon" aria-hidden="true">
+                  <Icon className={`${active ? "ph-fill" : "ph"} ph-${item.icon}`} />
+                </span>
+                <span className="kz-rail__label">{t(item.labelKey)}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+
+      <style jsx>{`
+        .kz-rail {
+          position: fixed;
+          left: 0;
+          top: 0;
+          bottom: 0;
+          width: var(--rail-w, 84px);
+          z-index: 95;
+          background: var(--surface-card);
+          border-right: 1px solid var(--border-subtle);
+          /* Clear the top header band so the first item sits below it. */
+          padding-top: 76px;
+          display: none;
+          overflow-y: auto;
+          overscroll-behavior: contain;
+        }
+        /* Desktop only — below lg the bottom tab bar is used instead. */
+        @media (min-width: 992px) {
+          .kz-rail {
+            display: block;
+          }
+        }
+
+        .kz-rail__list {
+          list-style: none;
+          margin: 0;
+          padding: 8px 10px;
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+
+        /* next-intl <Link> is a custom component, so styled-jsx can't scope to
+           its rendered <a>. Target via :global() under the scoped host; the
+           (0,2,0) specificity also beats the template's global "a" colour. */
+        .kz-rail :global(.kz-rail__link) {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          gap: 5px;
+          padding: 10px 4px;
+          border-radius: var(--radius-lg, 16px);
+          text-decoration: none;
+          color: var(--text-muted);
+          transition:
+            color var(--dur-fast, 0.15s) var(--ease-out, ease),
+            background-color var(--dur-fast, 0.15s) var(--ease-out, ease);
+        }
+        .kz-rail :global(.kz-rail__link:hover) {
+          color: var(--text-primary);
+          background: var(--surface-muted);
+        }
+        .kz-rail :global(.kz-rail__link.is-active) {
+          color: var(--brand);
+          background: var(--brand-soft);
+        }
+        .kz-rail :global(.kz-rail__link:focus-visible) {
+          outline: none;
+          box-shadow: var(--ring);
+        }
+
+        .kz-rail__icon {
+          display: inline-flex;
+          font-size: 25px;
+          line-height: 1;
+        }
+        .kz-rail__label {
+          font-size: 11px;
+          font-weight: 600;
+          letter-spacing: 0.01em;
+          line-height: 1.1;
+          text-align: center;
+        }
+
+        @media (min-width: 1280px) {
+          .kz-rail {
+            width: var(--rail-w-xl, 92px);
+          }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .kz-rail :global(.kz-rail__link) {
+            transition: none;
+          }
+        }
+      `}</style>
+    </aside>
+  );
+}

--- a/src/config/nav.js
+++ b/src/config/nav.js
@@ -1,0 +1,88 @@
+// ─── App-shell navigation model ──────────────────────────────────────────────
+// Single source of truth for the primary navigation rendered by the app shell:
+//   * mobile/tablet  → BottomTabBar  (5 slots, the `PRIMARY_NAV` list)
+//   * desktop (≥lg)  → SideRail      (the `RAIL_NAV` list — added next phase)
+//
+// Adding/reordering a destination = edit these arrays only; the shell surfaces
+// pick them up automatically. Labels are i18n keys in the `Nav` namespace;
+// icons are phosphor glyph names resolved by `@/components/Icon` (ICON_MAP).
+//
+// Item shape:
+//   { key, icon, labelKey,
+//     href?    — next-intl route (link item),
+//     action?  — global action id instead of navigation ("post-book"),
+//     match?   — extra path prefixes that mark this item active,
+//     center?  — render as the elevated center CTA (post button) }
+
+export const PRIMARY_NAV = [
+  { key: "home", icon: "house", labelKey: "Nav.home", href: "/" },
+  {
+    key: "books",
+    icon: "book-open-text",
+    labelKey: "Nav.books",
+    href: "/community/all",
+    match: ["/community", "/book-details", "/books"],
+  },
+  { key: "post", icon: "plus", labelKey: "Nav.post", action: "post-book", center: true },
+  {
+    key: "collections",
+    icon: "stack",
+    labelKey: "Nav.collections",
+    href: "/collections",
+    match: ["/collections", "/collection"],
+  },
+  {
+    key: "profile",
+    icon: "user-circle",
+    labelKey: "Nav.profile",
+    href: "/account",
+    match: ["/account", "/wishlist"],
+  },
+];
+
+// Desktop side rail can carry more destinations than the 5-slot mobile bar
+// (Shops gets its own entry instead of hiding under a drawer).
+export const RAIL_NAV = [
+  { key: "home", icon: "house", labelKey: "Nav.home", href: "/" },
+  {
+    key: "books",
+    icon: "book-open-text",
+    labelKey: "Nav.books",
+    href: "/community/all",
+    match: ["/community", "/book-details", "/books"],
+  },
+  {
+    key: "collections",
+    icon: "stack",
+    labelKey: "Nav.collections",
+    href: "/collections",
+    match: ["/collections", "/collection"],
+  },
+  { key: "shops", icon: "storefront", labelKey: "Nav.shops", href: "/shops", match: ["/shops"] },
+  {
+    key: "profile",
+    icon: "user-circle",
+    labelKey: "Nav.profile",
+    href: "/account",
+    match: ["/account", "/wishlist"],
+  },
+];
+
+// Pathnames (locale-prefix already stripped by next-intl's usePathname) where
+// the app-shell nav should not appear — auth flows own the full screen.
+const HIDDEN_SUFFIXES = ["/login", "/register", "/forgot-password", "/auth/auto"];
+
+export function isShellHiddenPath(pathname) {
+  if (!pathname) return false;
+  return HIDDEN_SUFFIXES.some((s) => pathname === s || pathname.endsWith(s));
+}
+
+// Active-state resolver shared by every shell surface so highlighting is
+// identical in the bottom bar and the rail. Home matches only "/"; everything
+// else matches its href prefix plus any extra `match` prefixes.
+export function isNavItemActive(item, pathname) {
+  if (!pathname || !item.href) return false;
+  if (item.href === "/") return pathname === "/";
+  const prefixes = [item.href, ...(item.match || [])];
+  return prefixes.some((p) => pathname === p || pathname.startsWith(`${p}/`) || pathname === p);
+}

--- a/src/hooks/usePostBookAction.js
+++ b/src/hooks/usePostBookAction.js
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { usePathname, useRouter } from "@/i18n/navigation";
+import { isAuthenticated, getUserProfile } from "@/services/auth";
+import { openPostChooser } from "@/lib/postBookModal";
+import { isProfileComplete } from "@/utils/profile";
+
+/**
+ * The single "post a book" entry-point gate, shared by every surface that can
+ * start the flow (the floating FAB and the app-shell bottom tab bar).
+ *
+ * Gate order — keep these in sync with the backend's `profile_incomplete`
+ * guard so the UX matches the server's final say:
+ *   1. Not logged in        → /login?next=<current page>
+ *   2. Incomplete profile    → /account?complete=book (editor auto-opens)
+ *   3. Otherwise             → open the post chooser
+ * A failed profile check (network) falls through to the chooser and lets the
+ * backend reject if needed, rather than blocking a legitimate post.
+ *
+ * Returns `{ trigger, checking }` — `checking` is true while the live profile
+ * lookup is in flight so callers can show a busy state.
+ */
+export function usePostBookAction() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [checking, setChecking] = useState(false);
+
+  const trigger = useCallback(async () => {
+    if (!isAuthenticated()) {
+      const next = encodeURIComponent(pathname || "/");
+      router.push(`/login?next=${next}`);
+      return;
+    }
+    setChecking(true);
+    try {
+      const { user } = await getUserProfile();
+      if (!isProfileComplete(user)) {
+        router.push("/account?complete=book");
+        return;
+      }
+      openPostChooser();
+    } catch {
+      openPostChooser();
+    } finally {
+      setChecking(false);
+    }
+  }, [router, pathname]);
+
+  return { trigger, checking };
+}
+
+export default usePostBookAction;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -76,6 +76,15 @@
     "language": "Language",
     "aboutUs": "About us"
   },
+  "Nav": {
+    "primary": "Primary navigation",
+    "home": "Home",
+    "books": "Books",
+    "post": "Post",
+    "collections": "Collections",
+    "profile": "Profile",
+    "shops": "Shops"
+  },
   "Common": {
     "location": "Location",
     "seller": "Seller",

--- a/src/messages/kaa.json
+++ b/src/messages/kaa.json
@@ -76,6 +76,15 @@
     "language": "Til",
     "aboutUs": "Biz haqqımızda"
   },
+  "Nav": {
+    "primary": "Tiykarǵı navigatsiya",
+    "home": "Bas bet",
+    "books": "Kitaplar",
+    "post": "Qosıw",
+    "collections": "Toplamlar",
+    "profile": "Profil",
+    "shops": "Dúkenler"
+  },
   "Common": {
     "location": "Jaylasıw",
     "seller": "Satıwshı",

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -76,6 +76,15 @@
     "language": "Язык",
     "aboutUs": "О нас"
   },
+  "Nav": {
+    "primary": "Основная навигация",
+    "home": "Главная",
+    "books": "Книги",
+    "post": "Разместить",
+    "collections": "Подборки",
+    "profile": "Профиль",
+    "shops": "Магазины"
+  },
   "Common": {
     "location": "Локация",
     "seller": "Продавец",

--- a/src/messages/uz.json
+++ b/src/messages/uz.json
@@ -76,6 +76,15 @@
     "language": "Til",
     "aboutUs": "Biz haqimizda"
   },
+  "Nav": {
+    "primary": "Asosiy navigatsiya",
+    "home": "Asosiy",
+    "books": "Kitoblar",
+    "post": "Joylash",
+    "collections": "To'plamlar",
+    "profile": "Profil",
+    "shops": "Do'konlar"
+  },
   "Common": {
     "location": "Joylashuv",
     "seller": "Sotuvchi",


### PR DESCRIPTION
## Nima

App-like redesign'ning **Phase 1–2** — yangi navigatsiya qobig'i (app shell) + global qidiruv + footer + header moslash. mutolaa.com uslubidan ilhomlangan; sayt endi mobil **va** desktopda ilova kabi ishlaydi.

### 1. App shell — navigatsiya
- **Mobil/planshet (< lg)** — bottom tab bar: `Asosiy · Kitoblar · (+) Joylash · To'plamlar · Profil`, branded markaziy CTA.
- **Desktop (≥ lg)** — chap sidebar rail: brand + `Asosiy · Kitoblar · To'plamlar · Do'konlar · Profil`, active item brand rangda.

### 2. Global qidiruv (yangi)
- Saytda ilgari **global qidiruv yo'q edi**. Endi: desktop header markazida prominent pill, mobil/planshetda header ostida to'liq kenglik qator.
- Submit → `/community/all?search=<term>` (CommunityBooksPage URL'dan seed qiladi, books API'ga `q` sifatida) — uchidan-uchiga, yangi sahifa/endpoint'siz.

### 3. Footer — app-like, minimal
- Bootstrap grid + inline style → **styled-jsx CSS grid**, token-driven. 1920px `body-bottom-bg` img olib tashlandi (audit P2).

### 4. Header — app-shellga moslash
- Desktop'da logo + hamburger yashirildi (rail + footer beradi) → slim top bar (qidiruv + utilities). Mobil header o'zgarmagan.

### 5. Design language (Phase 3)
- Ultra-clean surfaces: airier near-white page (#f4f5f7 → #f7f8fa), soyalar yengillashtirildi (hairline-driven minimal).
- Brand yashil chuqurlashtirildi/premium: hsl(148,59%,39%) → hsl(150,55%,35%), yagona manbadan (_variable.scss --main) butun yashil shkala + MUI + --brand sinxron.

## O'zgarishlar (asosiy)
- `src/config/nav.js` — navigatsiyaning yagona manbasi + `isNavItemActive`/`isShellHiddenPath`.
- `usePostBookAction()` — post-book gate shared hook; tab bar "+" va FAB bir xil.
- `BottomTabBar` / `SideRail` / `SearchBar` — yangi shell komponentlari (styled-jsx, `:global()` link-scoping).
- FAB endi desktop-only — audit FAB×nudge kolliziyasi yopildi.
- `FooterOne` / `BottomFooter` — token-driven app-like footer.
- `HeaderOne` — desktopda decluttered + global qidiruv.
- `globals.scss` — `--brand*` + `--rail-w` tokenlari, body inset.
- `Nav` i18n — 4 locale, i18n:check yashil.

## Test rejasi
- ✅ lint (toza) · ✅ 180/180 unit · ✅ build 7/7 · ✅ i18n 4-locale
- ✅ Playwright: 390px (tab bar + search row), 1440/1024 (rail + header search, submit → community?search=...), /login, footer

## Follow-up
- Phase 3: design language (accent/typografiya/spacing) refresh.
- Audit qoldiq P1/P2: CollectionCreateModal CTA pin, CommunityBooks filtr collapse, VendorsList pager, 32px touch-targetlar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
