### PR TITLE
fix(auth): code-only AuthRequiredModal — drop legacy phone+OTP login

### DIFF
--- a/src/components/auth/AuthRequiredModal.jsx
+++ b/src/components/auth/AuthRequiredModal.jsx
@@ -14,7 +14,7 @@ import {
   CircularProgress,
   Alert,
 } from "@mui/material";
-import { loginWithPhoneOtp } from "@/services/auth";
+import { loginWithCode } from "@/services/auth";
 import { mapValidationError } from "@/lib/mapValidationError";
 import { getBotUrl } from "@/config/env";
 import Icon from "@/components/Icon";
@@ -34,9 +34,9 @@ const BOT_DEEP_LINK = getBotUrl({ start: "login" });
  *   - Primary CTA opens the Telegram bot (`?start=login`). The bot's main
  *     menu offers two flows: "auto-login link" (one-tap return to the
  *     site) and "OTP code" (paste it here).
- *   - The inline form below is the OTP fallback — phone + 4–6-digit code
- *     → POST /auth/login/. On success we close the modal and let the
- *     user retry their original action.
+ *   - The inline form below is the code-only fallback — just the 6-digit
+ *     code (no phone), matching the canonical /login page (loginWithCode).
+ *     On success we close the modal and let the user retry their action.
  *
  * Design choice: we do NOT auto-replay the failed mutation. Mutation
  * payloads can contain FormData, idempotency keys, and ephemeral file
@@ -47,7 +47,6 @@ const AuthRequiredModal = () => {
   const t = useTranslations("AuthRequiredModal");
   const tCommon = useTranslations("Common");
   const [open, setOpen] = useState(false);
-  const [phone, setPhone] = useState("");
   const [code, setCode] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
@@ -73,7 +72,7 @@ const AuthRequiredModal = () => {
     setError(null);
   };
 
-  const canSubmit = !submitting && phone.trim().length >= 9 && code.trim().length >= 4;
+  const canSubmit = !submitting && code.trim().length >= 4;
 
   const handleSubmit = async (event) => {
     event?.preventDefault?.();
@@ -81,17 +80,13 @@ const AuthRequiredModal = () => {
     setSubmitting(true);
     setError(null);
     try {
-      const res = await loginWithPhoneOtp({
-        phone_number: phone.trim(),
-        otp_code: code.trim(),
-      });
+      const res = await loginWithCode(code.trim());
       if (res?.access_token) {
         setSuccess(true);
         // Give the user a beat to read the success state, then close.
         // Caller-side: they retry their original action manually.
         window.setTimeout(() => {
           setOpen(false);
-          setPhone("");
           setCode("");
         }, 900);
       } else {
@@ -203,23 +198,13 @@ const AuthRequiredModal = () => {
               <TextField
                 fullWidth
                 size="small"
-                type="tel"
-                label={t("phoneLabel")}
-                placeholder="+998 9X XXX XX XX"
-                value={phone}
-                onChange={(e) => setPhone(e.target.value)}
-                autoComplete="tel"
-                disabled={submitting}
-              />
-              <TextField
-                fullWidth
-                size="small"
                 label={t("codeLabel")}
                 placeholder="123456"
                 value={code}
                 onChange={(e) => setCode(e.target.value.replace(/[^0-9]/g, "").slice(0, 6))}
                 inputMode="numeric"
                 autoComplete="one-time-code"
+                autoFocus
                 disabled={submitting}
               />
               {error && (

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -22,49 +22,12 @@ function saveAccessToken(token, expiresIn = 4800) {
   setItem("token_expires_at", Date.now() + expiresIn * 1000);
 }
 
-export async function loginWithPhoneOtp({ phone_number, otp_code }) {
-  const { data } = await http.post(
-    API_ENDPOINTS.AUTH.LOGIN,
-    {
-      phone_number,
-      otp_code,
-    },
-    withIdempotency(),
-  );
-
-  const accessToken = data?.access_token;
-  const refreshToken = data?.refresh_token;
-  const expiresIn = data?.expires_in || data?.expires_in_seconds;
-
-  if (accessToken) {
-    saveAccessToken(accessToken, expiresIn);
-    setItem("login_time", Date.now());
-  }
-
-  // C-4: in cookie mode the refresh token arrives via an HttpOnly Set-Cookie,
-  // so we never persist it in JS-readable storage. Body mode keeps the old path.
-  if (refreshToken && !COOKIE_REFRESH) {
-    setItem("refresh_token", refreshToken);
-  }
-
-  devLog("🔐 Login successful", {
-    hasAccessToken: !!accessToken,
-    hasRefreshToken: !!refreshToken,
-    expiresIn,
-  });
-
-  return {
-    access_token: accessToken || null,
-    refresh_token: refreshToken || null,
-    user: data?.user || null,
-    expiresIn: expiresIn || null,
-  };
-}
-
 /**
- * Code-only login. The bot mints a short-lived 6-digit OTP; the user types
- * it once, no phone number step. Server resolves the user from the active
- * OTP row and returns the same JWT envelope as loginWithPhoneOtp.
+ * Code-only login — the single canonical sign-in path. The bot mints a
+ * short-lived 6-digit OTP; the user types it once, no phone number step.
+ * Server resolves the user from the active OTP row and returns the JWT
+ * envelope. (The legacy phone+OTP `loginWithPhoneOtp` was removed — every
+ * surface now uses this code-only flow.)
  */
 export async function loginWithCode(otp_code) {
   const { data } = await http.post(

--- a/tests/unit/cookieAuth.test.js
+++ b/tests/unit/cookieAuth.test.js
@@ -25,7 +25,7 @@ import { COOKIE_REFRESH } from "@/config";
 import { setItem } from "@/utils/storage";
 import {
   refreshAccessToken,
-  loginWithPhoneOtp,
+  loginWithCode,
   isRefreshTokenExpired,
   hasRefreshSession,
   logoutUser,
@@ -55,7 +55,7 @@ describe("cookie-mode auth (C-4)", () => {
     post.mockResolvedValue({
       data: { access_token: "AAA", refresh_token: "RRR", expires_in_seconds: 4800 },
     });
-    await loginWithPhoneOtp({ phone_number: "+998900000000", otp_code: "123456" });
+    await loginWithCode("123456");
     const keys = setItem.mock.calls.map((c) => c[0]);
     expect(keys).toContain("auth_token");
     expect(keys).toContain("login_time");


### PR DESCRIPTION
## Muammo
"Avval tizimga kiring" modali (auth-kerak amallarda chiqadi) hali eski **telefon + OTP** oqimini (`loginWithPhoneOtp`) ishlatardi — telefon raqami so'rardi. Bu haqiqiy `/login` sahifasiga zid: u **kod-only** (bot 6-xonali kod beradi, user kiritadi, telefonsiz).

## Yechim
- `AuthRequiredModal` endi `loginWithCode(code)` ishlatadi, **telefon maydoni olib tashlandi** — login sahifasi bilan bir xil: bot CTA + bitta OTP kod maydoni (autofocus). Body matni allaqachon bot-kod oqimini tasvirlardi.
- O'lik `loginWithPhoneOtp` `services/auth.js` dan olib tashlandi (boshqa chaqiruvchi yo'q edi — yagona telefon-so'rovchi login UI shu edi). `loginWithCode` — yagona kanonik kirish yo'li.

## Test
- ✅ lint · ✅ build 7/7
- Lokal `auth:required` dispatch — modalda **0 ta telefon input**, faqat kod maydoni (screenshot bilan tasdiqlangan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)