### PR TITLE
Share to Telegram via bot deep-link (formatted forwards)

### DIFF
--- a/src/components/BookCard.jsx
+++ b/src/components/BookCard.jsx
@@ -6,6 +6,7 @@ import { useLike } from "@/hooks/useLike";
 import { useAuth } from "@/hooks/useAuth";
 import { formatPrice } from "@/utils/formatPrice";
 import { openShareSheet } from "@/lib/shareSheet";
+import { getBotUrl } from "@/config/env";
 import { resolveMediaUrl } from "@/utils/mediaUrl";
 import { bookOwnerLocation } from "@/utils/location";
 import { bookTypeVisual, bookTypeI18nKey } from "@/utils/bookType";
@@ -98,6 +99,7 @@ const BookCard = ({
         ? tShare("bookCaption", { name: bookName, author: bookAuthor })
         : tShare("bookCaptionNoAuthor", { name: bookName }),
       url: `/${locale}/book-details/${book.id}`,
+      telegramUrl: getBotUrl({ start: `share_book_${locale}_${book.id}` }),
     });
   };
 

--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -18,6 +18,7 @@ import { trackEvent } from "@/lib/analytics";
 import { useLike } from "@/hooks/useLike";
 import { useAuth } from "@/hooks/useAuth";
 import { openShareSheet } from "@/lib/shareSheet";
+import { getBotUrl } from "@/config/env";
 import { resolveMediaUrl } from "@/utils/mediaUrl";
 import { localizedField } from "@/utils/localizedField";
 import { bookTypeVisual, bookTypeI18nKey } from "@/utils/bookType";
@@ -164,6 +165,7 @@ const BookDetails = ({ bookId }) => {
         ? tShare("bookCaption", { name: bookTitle, author: bookAuthor })
         : tShare("bookCaptionNoAuthor", { name: bookTitle }),
       url: typeof window !== "undefined" ? window.location.pathname : "",
+      telegramUrl: getBotUrl({ start: `share_book_${locale}_${book.id}` }),
     });
   };
 
@@ -187,6 +189,8 @@ const BookDetails = ({ bookId }) => {
       title: bookTitle,
       text,
       url: typeof window !== "undefined" ? window.location.pathname : "",
+      // mode is "gift" | "wish" → share_gift_… / share_wish_…
+      telegramUrl: getBotUrl({ start: `share_${mode}_${locale}_${book.id}` }),
     });
   };
 

--- a/src/components/ShareSheet.jsx
+++ b/src/components/ShareSheet.jsx
@@ -130,7 +130,13 @@ const ShareSheet = ({ open, payload, onClose }) => {
       icon: "ph-fill ph-telegram-logo",
       color: "#229ED9",
       bg: "rgba(34, 158, 217, 0.12)",
-      onClick: () => openAndClose(`https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`),
+      // A bot deep-link (payload.telegramUrl) makes the bot hand the user a
+      // fully HTML-formatted, ready-to-forward card. Falls back to the plain
+      // t.me/share/url path when a caller doesn't supply one.
+      onClick: () =>
+        openAndClose(
+          payload?.telegramUrl || `https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`,
+        ),
     },
     {
       key: "whatsapp",

--- a/src/components/ShopDetailPage.jsx
+++ b/src/components/ShopDetailPage.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import {
   Box,
   Stack,
@@ -24,6 +24,7 @@ import { openPostChooser } from "@/lib/postBookModal";
 import { getBookCategories, getBookSubcategories } from "@/services/categories";
 import BookRowGrid from "@/components/shared/BookRowGrid";
 import { openShareSheet } from "@/lib/shareSheet";
+import { getBotUrl } from "@/config/env";
 import ShopBannerCarousel from "@/components/ShopBannerCarousel";
 import Icon from "@/components/Icon";
 
@@ -105,6 +106,7 @@ const ShopDetailPage = ({ shopId }) => {
   const tShare = useTranslations("Share");
   const tShopEdit = useTranslations("ShopEdit");
   const tShopLoc = useTranslations("ShopLocation");
+  const locale = useLocale();
 
   const handleShareShop = () => {
     const name = shop?.name || "Kitobzor";
@@ -112,6 +114,7 @@ const ShopDetailPage = ({ shopId }) => {
       title: name,
       text: tShare("shopCaption", { name }),
       url: typeof window !== "undefined" ? window.location.pathname : "",
+      telegramUrl: shopId ? getBotUrl({ start: `share_shop_${locale}_${shopId}` }) : undefined,
     });
   };
 

--- a/src/lib/shareSheet.js
+++ b/src/lib/shareSheet.js
@@ -5,13 +5,20 @@
  * and the mount-point in the layout renders the bottom-sheet with a list
  * of share targets (Telegram, WhatsApp, SMS, Facebook, X, email, copy).
  * Keeps the sheet's chunk lazy — bytes ship only after the first share.
+ *
+ * `telegramUrl` (optional): overrides the Telegram target's destination. We
+ * pass a bot deep-link (`t.me/<bot>?start=share_...`) here so the Telegram
+ * tile opens the bot, which then hands the user a fully HTML-formatted,
+ * ready-to-forward card (bold + quote + link) — something the plain-text
+ * `t.me/share/url` deep-link can never render. Other targets (WhatsApp,
+ * native share, …) keep using `text`/`url` as before.
  */
 
 const EVENT = "share-sheet:open";
 
 export const SHARE_SHEET_EVENT = EVENT;
 
-export function openShareSheet({ title = "", text = "", url = "" } = {}) {
+export function openShareSheet({ title = "", text = "", url = "", telegramUrl = "" } = {}) {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent(EVENT, { detail: { title, text, url } }));
+  window.dispatchEvent(new CustomEvent(EVENT, { detail: { title, text, url, telegramUrl } }));
 }


### PR DESCRIPTION
## What
The Telegram share tile now opens a **bot deep-link** (`getBotUrl({ start: 'share_<kind>_<lang>_<id>' })`) instead of the plain-text `t.me/share/url`. The bot then hands the user a fully HTML-formatted, ready-to-forward card (bold + quote + link) — which the plain-text share path can never render.

- `lib/shareSheet.js` + `ShareSheet.jsx`: optional `telegramUrl` override on the Telegram target; other targets unchanged.
- Wired at `BookDetails` (share + gift/wish), `BookCard`, `ShopDetailPage`.
- Reuses the existing `getBotUrl` / `NEXT_PUBLIC_BOT_USERNAME` plumbing (same as site-login). Bot side ships in backend repo (`handlers/share.py`).

## Tests
- `npm run lint` clean (pre-existing `<img>` warning only), `npm run i18n:check` OK, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)