### PR TITLE
Keep Share-to-Telegram direct (revert bot deep-link) + caption polish

### DIFF
--- a/src/components/BookCard.jsx
+++ b/src/components/BookCard.jsx
@@ -6,7 +6,6 @@ import { useLike } from "@/hooks/useLike";
 import { useAuth } from "@/hooks/useAuth";
 import { formatPrice } from "@/utils/formatPrice";
 import { openShareSheet } from "@/lib/shareSheet";
-import { getBotUrl } from "@/config/env";
 import { resolveMediaUrl } from "@/utils/mediaUrl";
 import { bookOwnerLocation } from "@/utils/location";
 import { bookTypeVisual, bookTypeI18nKey } from "@/utils/bookType";
@@ -99,7 +98,6 @@ const BookCard = ({
         ? tShare("bookCaption", { name: bookName, author: bookAuthor })
         : tShare("bookCaptionNoAuthor", { name: bookName }),
       url: `/${locale}/book-details/${book.id}`,
-      telegramUrl: getBotUrl({ start: `share_book_${locale}_${book.id}` }),
     });
   };
 

--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -18,7 +18,6 @@ import { trackEvent } from "@/lib/analytics";
 import { useLike } from "@/hooks/useLike";
 import { useAuth } from "@/hooks/useAuth";
 import { openShareSheet } from "@/lib/shareSheet";
-import { getBotUrl } from "@/config/env";
 import { resolveMediaUrl } from "@/utils/mediaUrl";
 import { localizedField } from "@/utils/localizedField";
 import { bookTypeVisual, bookTypeI18nKey } from "@/utils/bookType";
@@ -165,7 +164,6 @@ const BookDetails = ({ bookId }) => {
         ? tShare("bookCaption", { name: bookTitle, author: bookAuthor })
         : tShare("bookCaptionNoAuthor", { name: bookTitle }),
       url: typeof window !== "undefined" ? window.location.pathname : "",
-      telegramUrl: getBotUrl({ start: `share_book_${locale}_${book.id}` }),
     });
   };
 
@@ -189,8 +187,6 @@ const BookDetails = ({ bookId }) => {
       title: bookTitle,
       text,
       url: typeof window !== "undefined" ? window.location.pathname : "",
-      // mode is "gift" | "wish" → share_gift_… / share_wish_…
-      telegramUrl: getBotUrl({ start: `share_${mode}_${locale}_${book.id}` }),
     });
   };
 

--- a/src/components/ShareSheet.jsx
+++ b/src/components/ShareSheet.jsx
@@ -130,13 +130,7 @@ const ShareSheet = ({ open, payload, onClose }) => {
       icon: "ph-fill ph-telegram-logo",
       color: "#229ED9",
       bg: "rgba(34, 158, 217, 0.12)",
-      // A bot deep-link (payload.telegramUrl) makes the bot hand the user a
-      // fully HTML-formatted, ready-to-forward card. Falls back to the plain
-      // t.me/share/url path when a caller doesn't supply one.
-      onClick: () =>
-        openAndClose(
-          payload?.telegramUrl || `https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`,
-        ),
+      onClick: () => openAndClose(`https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`),
     },
     {
       key: "whatsapp",

--- a/src/components/ShopDetailPage.jsx
+++ b/src/components/ShopDetailPage.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { useTranslations, useLocale } from "next-intl";
+import { useTranslations } from "next-intl";
 import {
   Box,
   Stack,
@@ -24,7 +24,6 @@ import { openPostChooser } from "@/lib/postBookModal";
 import { getBookCategories, getBookSubcategories } from "@/services/categories";
 import BookRowGrid from "@/components/shared/BookRowGrid";
 import { openShareSheet } from "@/lib/shareSheet";
-import { getBotUrl } from "@/config/env";
 import ShopBannerCarousel from "@/components/ShopBannerCarousel";
 import Icon from "@/components/Icon";
 
@@ -106,7 +105,6 @@ const ShopDetailPage = ({ shopId }) => {
   const tShare = useTranslations("Share");
   const tShopEdit = useTranslations("ShopEdit");
   const tShopLoc = useTranslations("ShopLocation");
-  const locale = useLocale();
 
   const handleShareShop = () => {
     const name = shop?.name || "Kitobzor";
@@ -114,7 +112,6 @@ const ShopDetailPage = ({ shopId }) => {
       title: name,
       text: tShare("shopCaption", { name }),
       url: typeof window !== "undefined" ? window.location.pathname : "",
-      telegramUrl: shopId ? getBotUrl({ start: `share_shop_${locale}_${shopId}` }) : undefined,
     });
   };
 

--- a/src/lib/shareSheet.js
+++ b/src/lib/shareSheet.js
@@ -5,20 +5,13 @@
  * and the mount-point in the layout renders the bottom-sheet with a list
  * of share targets (Telegram, WhatsApp, SMS, Facebook, X, email, copy).
  * Keeps the sheet's chunk lazy — bytes ship only after the first share.
- *
- * `telegramUrl` (optional): overrides the Telegram target's destination. We
- * pass a bot deep-link (`t.me/<bot>?start=share_...`) here so the Telegram
- * tile opens the bot, which then hands the user a fully HTML-formatted,
- * ready-to-forward card (bold + quote + link) — something the plain-text
- * `t.me/share/url` deep-link can never render. Other targets (WhatsApp,
- * native share, …) keep using `text`/`url` as before.
  */
 
 const EVENT = "share-sheet:open";
 
 export const SHARE_SHEET_EVENT = EVENT;
 
-export function openShareSheet({ title = "", text = "", url = "", telegramUrl = "" } = {}) {
+export function openShareSheet({ title = "", text = "", url = "" } = {}) {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent(EVENT, { detail: { title, text, url, telegramUrl } }));
+  window.dispatchEvent(new CustomEvent(EVENT, { detail: { title, text, url } }));
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1014,9 +1014,9 @@
     "targetCopy": "Copy link",
     "targetInstagram": "Instagram",
     "instagramHint": "Link copied — paste it in your Instagram story or DM",
-    "bookCaption": "📖 “{name}” — {author}\nDetails and seller contact — at the link",
-    "bookCaptionNoAuthor": "📖 “{name}”\nDetails and seller contact — at the link",
-    "shopCaption": "🏬 “{name}” — a shop on Kitobzor\nIts books and address — at the link",
+    "bookCaption": "📖 “{name}” — {author}\n\nDetails and seller contact — at the link",
+    "bookCaptionNoAuthor": "📖 “{name}”\n\nDetails and seller contact — at the link",
+    "shopCaption": "🏬 “{name}” — a shop on Kitobzor\n\nIts books and address — at the link",
     "profileCaption": "👤 {name} — a profile on Kitobzor\nTheir books — at the link"
   },
   "Vendor": {

--- a/src/messages/kaa.json
+++ b/src/messages/kaa.json
@@ -1014,9 +1014,9 @@
     "targetCopy": "Siltemeni kóshiriw",
     "targetInstagram": "Instagram",
     "instagramHint": "Silteme kóshirildi — Instagram'da story yáki DM'ge qoyıń",
-    "bookCaption": "📖 «{name}» — {author}\nTolıq maǵlıwmat hám iyesi menen baylanıs — siltemede",
-    "bookCaptionNoAuthor": "📖 «{name}»\nTolıq maǵlıwmat hám iyesi menen baylanıs — siltemede",
-    "shopCaption": "🏬 «{name}» — Kitobzor'dagı dúken\nKitapları hám mánzili siltemede",
+    "bookCaption": "📖 «{name}» — {author}\n\nTolıq maǵlıwmat hám iyesi menen baylanıs — siltemede",
+    "bookCaptionNoAuthor": "📖 «{name}»\n\nTolıq maǵlıwmat hám iyesi menen baylanıs — siltemede",
+    "shopCaption": "🏬 «{name}» — Kitobzor'dagı dúken\n\nKitapları hám mánzili siltemede",
     "profileCaption": "👤 {name} — Kitobzor'dagı profil\nJaylastırǵan kitapları siltemede"
   },
   "Vendor": {

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -1014,9 +1014,9 @@
     "targetCopy": "Скопировать ссылку",
     "targetInstagram": "Instagram",
     "instagramHint": "Ссылка скопирована — вставьте её в Instagram сторис или ЛС",
-    "bookCaption": "📖 «{name}» — {author}\nПодробности и связь с владельцем — по ссылке",
-    "bookCaptionNoAuthor": "📖 «{name}»\nПодробности и связь с владельцем — по ссылке",
-    "shopCaption": "🏬 «{name}» — магазин на Kitobzor\nКниги и адрес — по ссылке",
+    "bookCaption": "📖 «{name}» — {author}\n\nПодробности и связь с владельцем — по ссылке",
+    "bookCaptionNoAuthor": "📖 «{name}»\n\nПодробности и связь с владельцем — по ссылке",
+    "shopCaption": "🏬 «{name}» — магазин на Kitobzor\n\nКниги и адрес — по ссылке",
     "profileCaption": "👤 {name} — профиль на Kitobzor\nЕго книги — по ссылке"
   },
   "Vendor": {

--- a/src/messages/uz.json
+++ b/src/messages/uz.json
@@ -1014,9 +1014,9 @@
     "targetCopy": "Havolani nusxalash",
     "targetInstagram": "Instagram",
     "instagramHint": "Havola nusxalandi — Instagram'da story yoki DM'ga qo'ying",
-    "bookCaption": "📖 «{name}» — {author}\nTafsilotlar va egasi bilan bog'lanish — havolada",
-    "bookCaptionNoAuthor": "📖 «{name}»\nTafsilotlar va egasi bilan bog'lanish — havolada",
-    "shopCaption": "🏬 «{name}» — Kitobzor'dagi do'kon\nKitoblari va manzili havolada",
+    "bookCaption": "📖 «{name}» — {author}\n\nTafsilotlar va egasi bilan bog'lanish — havolada",
+    "bookCaptionNoAuthor": "📖 «{name}»\n\nTafsilotlar va egasi bilan bog'lanish — havolada",
+    "shopCaption": "🏬 «{name}» — Kitobzor'dagi do'kon\n\nKitoblari va manzili havolada",
     "profileCaption": "👤 {name} — Kitobzor'dagi profil\nJoylagan kitoblari havolada"
   },
   "Vendor": {


### PR DESCRIPTION
Reverts the `telegramUrl` bot-deep-link wiring (bus + ShareSheet + BookDetails/BookCard/ShopDetailPage) so every Telegram share goes straight to the chosen chat via `t.me/share/url` again — one tap, no bot hop. Adds a paragraph break to the book/shop share captions (uz/ru/en/kaa) for breathing room. Pairs with backend revert PR menOtabek/kitobzor#112.

Lint clean, `i18n:check` OK (922 keys in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)