### PR TITLE
Share: blank line between message and link

### DIFF
--- a/src/components/ShareSheet.jsx
+++ b/src/components/ShareSheet.jsx
@@ -46,16 +46,24 @@ const ShareSheet = ({ open, payload, onClose }) => {
     };
   }, [open, onClose]);
 
-  const { absoluteUrl, encodedUrl, encodedText, encodedTitle } = useMemo(() => {
-    const u = buildAbsoluteUrl(payload?.url || "");
-    const text = payload?.text || payload?.title || "";
-    return {
-      absoluteUrl: u,
-      encodedUrl: encodeURIComponent(u),
-      encodedText: encodeURIComponent(text),
-      encodedTitle: encodeURIComponent(payload?.title || ""),
-    };
-  }, [payload?.url, payload?.text, payload?.title]);
+  const { absoluteUrl, encodedUrl, encodedText, encodedTextTg, encodedTextGap, encodedTitle } =
+    useMemo(() => {
+      const u = buildAbsoluteUrl(payload?.url || "");
+      const text = payload?.text || payload?.title || "";
+      return {
+        absoluteUrl: u,
+        encodedUrl: encodeURIComponent(u),
+        encodedText: encodeURIComponent(text),
+        // Layout goal: caption, a blank line, then the link.
+        // Telegram joins its `text` param with the `url` using a single
+        // "\n", so a trailing "\n" here becomes a blank line before the link.
+        encodedTextTg: encodeURIComponent(text ? `${text}\n` : ""),
+        // WhatsApp / SMS: we concatenate the url ourselves, so a full blank
+        // line ("\n\n") sits between the caption and the link.
+        encodedTextGap: encodeURIComponent(text ? `${text}\n\n` : ""),
+        encodedTitle: encodeURIComponent(payload?.title || ""),
+      };
+    }, [payload?.url, payload?.text, payload?.title]);
 
   const openAndClose = useCallback(
     (href) => {
@@ -130,7 +138,7 @@ const ShareSheet = ({ open, payload, onClose }) => {
       icon: "ph-fill ph-telegram-logo",
       color: "#229ED9",
       bg: "rgba(34, 158, 217, 0.12)",
-      onClick: () => openAndClose(`https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`),
+      onClick: () => openAndClose(`https://t.me/share/url?url=${encodedUrl}&text=${encodedTextTg}`),
     },
     {
       key: "whatsapp",
@@ -138,7 +146,7 @@ const ShareSheet = ({ open, payload, onClose }) => {
       icon: "ph-fill ph-whatsapp-logo",
       color: "#25D366",
       bg: "rgba(37, 211, 102, 0.12)",
-      onClick: () => openAndClose(`https://wa.me/?text=${encodedText}%20${encodedUrl}`),
+      onClick: () => openAndClose(`https://wa.me/?text=${encodedTextGap}${encodedUrl}`),
     },
     {
       key: "instagram",
@@ -156,7 +164,7 @@ const ShareSheet = ({ open, payload, onClose }) => {
       bg: "rgba(22, 163, 74, 0.12)",
       onClick: () => {
         if (typeof window !== "undefined") {
-          window.location.href = `sms:?&body=${encodedText}%20${encodedUrl}`;
+          window.location.href = `sms:?&body=${encodedTextGap}${encodedUrl}`;
         }
         onClose?.();
       },

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1014,9 +1014,9 @@
     "targetCopy": "Copy link",
     "targetInstagram": "Instagram",
     "instagramHint": "Link copied — paste it in your Instagram story or DM",
-    "bookCaption": "📖 “{name}” — {author}\n\nDetails and seller contact — at the link",
-    "bookCaptionNoAuthor": "📖 “{name}”\n\nDetails and seller contact — at the link",
-    "shopCaption": "🏬 “{name}” — a shop on Kitobzor\n\nIts books and address — at the link",
+    "bookCaption": "📖 “{name}” — {author}\nDetails and seller contact — at the link.",
+    "bookCaptionNoAuthor": "📖 “{name}”\nDetails and seller contact — at the link.",
+    "shopCaption": "🏬 “{name}” — a shop on Kitobzor\nIts books and address — at the link.",
     "profileCaption": "👤 {name} — a profile on Kitobzor\nTheir books — at the link"
   },
   "Vendor": {

--- a/src/messages/kaa.json
+++ b/src/messages/kaa.json
@@ -1014,9 +1014,9 @@
     "targetCopy": "Siltemeni kóshiriw",
     "targetInstagram": "Instagram",
     "instagramHint": "Silteme kóshirildi — Instagram'da story yáki DM'ge qoyıń",
-    "bookCaption": "📖 «{name}» — {author}\n\nTolıq maǵlıwmat hám iyesi menen baylanıs — siltemede",
-    "bookCaptionNoAuthor": "📖 «{name}»\n\nTolıq maǵlıwmat hám iyesi menen baylanıs — siltemede",
-    "shopCaption": "🏬 «{name}» — Kitobzor'dagı dúken\n\nKitapları hám mánzili siltemede",
+    "bookCaption": "📖 «{name}» — {author}\nTolıq maǵlıwmat hám iyesi menen baylanıs — siltemede.",
+    "bookCaptionNoAuthor": "📖 «{name}»\nTolıq maǵlıwmat hám iyesi menen baylanıs — siltemede.",
+    "shopCaption": "🏬 «{name}» — Kitobzor'dagı dúken\nKitapları hám mánzili siltemede.",
     "profileCaption": "👤 {name} — Kitobzor'dagı profil\nJaylastırǵan kitapları siltemede"
   },
   "Vendor": {

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -1014,9 +1014,9 @@
     "targetCopy": "Скопировать ссылку",
     "targetInstagram": "Instagram",
     "instagramHint": "Ссылка скопирована — вставьте её в Instagram сторис или ЛС",
-    "bookCaption": "📖 «{name}» — {author}\n\nПодробности и связь с владельцем — по ссылке",
-    "bookCaptionNoAuthor": "📖 «{name}»\n\nПодробности и связь с владельцем — по ссылке",
-    "shopCaption": "🏬 «{name}» — магазин на Kitobzor\n\nКниги и адрес — по ссылке",
+    "bookCaption": "📖 «{name}» — {author}\nПодробности и связь с владельцем — по ссылке.",
+    "bookCaptionNoAuthor": "📖 «{name}»\nПодробности и связь с владельцем — по ссылке.",
+    "shopCaption": "🏬 «{name}» — магазин на Kitobzor\nКниги и адрес — по ссылке.",
     "profileCaption": "👤 {name} — профиль на Kitobzor\nЕго книги — по ссылке"
   },
   "Vendor": {

--- a/src/messages/uz.json
+++ b/src/messages/uz.json
@@ -1014,9 +1014,9 @@
     "targetCopy": "Havolani nusxalash",
     "targetInstagram": "Instagram",
     "instagramHint": "Havola nusxalandi — Instagram'da story yoki DM'ga qo'ying",
-    "bookCaption": "📖 «{name}» — {author}\n\nTafsilotlar va egasi bilan bog'lanish — havolada",
-    "bookCaptionNoAuthor": "📖 «{name}»\n\nTafsilotlar va egasi bilan bog'lanish — havolada",
-    "shopCaption": "🏬 «{name}» — Kitobzor'dagi do'kon\n\nKitoblari va manzili havolada",
+    "bookCaption": "📖 «{name}» — {author}\nTafsilotlar va egasi bilan bog'lanish — havolada.",
+    "bookCaptionNoAuthor": "📖 «{name}»\nTafsilotlar va egasi bilan bog'lanish — havolada.",
+    "shopCaption": "🏬 «{name}» — Kitobzor'dagi do'kon\nKitoblari va manzili havolada.",
     "profileCaption": "👤 {name} — Kitobzor'dagi profil\nJoylagan kitoblari havolada"
   },
   "Vendor": {


### PR DESCRIPTION
Shared message now reads: caption, a blank line, then the link. Telegram joins its share `text` with the `url` via a single newline, so a trailing `\n` on the Telegram text produces the blank line; WhatsApp/SMS concatenate the url themselves, so a `\n\n` goes between. Book/shop captions compacted to a single line + trailing period so the message is one tidy block above the gap.

Lint clean, i18n 922 keys in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)