### PR TITLE
Release: Telegram bot handle default fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,10 @@ NEXT_PUBLIC_SUPPORT_PHONE=+998 93 834 01 03
 # Telegram bot username (no @, no t.me prefix). Used by the login page
 # to render a "go to bot" link and by the AuthRequiredModal deep-link.
 # Per env (.env.local / .env.production) so dev points at a test bot.
-# Default (when unset): kitobzoruz_bot.
-NEXT_PUBLIC_BOT_USERNAME=kitobzoruz_bot
+# Must match the bot configured on the backend, otherwise the login code is
+# sent by a different bot than the "go to bot" link opens.
+# Default (when unset): kitobzorim_bot (the live dev/prod bot).
+NEXT_PUBLIC_BOT_USERNAME=kitobzorim_bot
 
 # Social channels — referenced from the footer + JSON-LD `sameAs`.
 # Handles only (no @, no full URL). Defaults match the production accounts.

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -69,7 +69,13 @@ export function getSentryRelease() {
   return (process.env.NEXT_PUBLIC_SENTRY_RELEASE || "").trim();
 }
 
-const DEFAULT_BOT_USERNAME = "kitobzoruz_bot";
+// Must be a bot that actually exists, so a forgotten NEXT_PUBLIC_BOT_USERNAME
+// at build time still yields a working "go to bot" link instead of a dead
+// t.me profile. This is the live bot backing the dev/prod deploy — keep it in
+// sync with .env.production.example. (The old `kitobzoruz_bot` default pointed
+// at a non-existent handle, so any build with the env unset silently broke the
+// login + AuthRequiredModal deep-links.)
+const DEFAULT_BOT_USERNAME = "kitobzorim_bot";
 
 /**
  * Telegram bot handle (no leading @). Default kept so a forgotten env

--- a/tests/unit/botLink.test.js
+++ b/tests/unit/botLink.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// The login page + AuthRequiredModal render a Telegram "go to bot" deep-link
+// from getBotUrl(). When NEXT_PUBLIC_BOT_USERNAME is unset (env drift on a
+// rebuild), the link falls back to a default handle — that default MUST be a
+// bot that actually exists, otherwise the link opens a dead t.me profile and
+// the whole OTP login flow is unreachable. This pins that contract.
+
+const ENV_KEY = "NEXT_PUBLIC_BOT_USERNAME";
+
+async function freshEnv() {
+  // env.js reads process.env at call time, but Vite caches the module — reset
+  // the registry so each case re-imports with the current process.env.
+  const mod = await import("@/config/env");
+  return mod;
+}
+
+describe("getBotUsername / getBotUrl", () => {
+  let original;
+
+  beforeEach(() => {
+    original = process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = original;
+  });
+
+  it("defaults to the live bot when the env var is unset", async () => {
+    delete process.env[ENV_KEY];
+    const { getBotUsername, getBotUrl } = await freshEnv();
+    // The live dev/prod bot — must stay in sync with .env.production.example.
+    expect(getBotUsername()).toBe("kitobzorim_bot");
+    expect(getBotUrl()).toBe("https://t.me/kitobzorim_bot");
+    expect(getBotUrl({ start: "login" })).toBe("https://t.me/kitobzorim_bot?start=login");
+  });
+
+  it("uses the configured handle and strips @ / t.me prefixes", async () => {
+    process.env[ENV_KEY] = "@custom_bot";
+    const { getBotUsername } = await freshEnv();
+    expect(getBotUsername()).toBe("custom_bot");
+
+    process.env[ENV_KEY] = "https://t.me/other_bot";
+    const again = await freshEnv();
+    expect(again.getBotUsername()).toBe("other_bot");
+  });
+});


### PR DESCRIPTION
Promote dev → main. Frontend-only, no migration.

Shipped: correct the `DEFAULT_BOT_USERNAME` fallback (`kitobzoruz_bot` → `kitobzorim_bot`) so a build with `NEXT_PUBLIC_BOT_USERNAME` unset yields a working "go to bot" deep-link instead of a dead t.me profile; align `.env.example`; add a unit test. No behavior change where the env var is set (dev/prod supply it via `.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)