### PR TITLE
chore: document per-env Telegram bot handles (local/dev/prod)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@ NEXT_PUBLIC_SUPPORT_PHONE=+998 93 834 01 03
 # Per env (.env.local / .env.production) so dev points at a test bot.
 # Must match the bot configured on the backend, otherwise the login code is
 # sent by a different bot than the "go to bot" link opens.
-# Default (when unset): kitobzorim_bot (the live dev/prod bot).
+# Per env: local=kitobzorim_bot (the default below), dev=octagonuzbot,
+# prod=kitobzor_uz_bot (dev/prod set their own value in the server .env).
 NEXT_PUBLIC_BOT_USERNAME=kitobzorim_bot
 
 # Social channels — referenced from the footer + JSON-LD `sameAs`.

--- a/.env.production.example
+++ b/.env.production.example
@@ -13,7 +13,8 @@ NEXT_PUBLIC_SUPPORT_PHONE=+998958430820
 
 # Telegram bot for OTP / auto-login. Must match the bot configured on the
 # backend (dev) — otherwise the login code is sent by a different bot.
-NEXT_PUBLIC_BOT_USERNAME=kitobzorim_bot
+# Per env: dev=octagonuzbot, prod=kitobzor_uz_bot, local=kitobzorim_bot.
+NEXT_PUBLIC_BOT_USERNAME=octagonuzbot
 
 # Optional Sentry DSN (leave empty to disable).
 NEXT_PUBLIC_SENTRY_DSN=

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -69,12 +69,16 @@ export function getSentryRelease() {
   return (process.env.NEXT_PUBLIC_SENTRY_RELEASE || "").trim();
 }
 
-// Must be a bot that actually exists, so a forgotten NEXT_PUBLIC_BOT_USERNAME
-// at build time still yields a working "go to bot" link instead of a dead
-// t.me profile. This is the live bot backing the dev/prod deploy — keep it in
-// sync with .env.production.example. (The old `kitobzoruz_bot` default pointed
-// at a non-existent handle, so any build with the env unset silently broke the
-// login + AuthRequiredModal deep-links.)
+// Per-environment bot (each deploy sets NEXT_PUBLIC_BOT_USERNAME in its own
+// server .env; this default only applies when the env var is unset — i.e. local
+// dev). The handle MUST match the bot configured on that env's backend, else
+// "go to bot" opens one bot while a different one sends the OTP code.
+//   local → kitobzorim_bot (this default)
+//   dev   → octagonuzbot     (/opt/kitobzor-frontend/.env on kitobzor-dev)
+//   prod  → kitobzor_uz_bot  (/opt/kitobzor-frontend/.env on kitobzor-prod)
+// Keep this in sync with .env.example (the local template). The old
+// `kitobzoruz_bot` default was a non-existent handle, so any build with the env
+// unset silently shipped dead login + AuthRequiredModal deep-links.
 const DEFAULT_BOT_USERNAME = "kitobzorim_bot";
 
 /**


### PR DESCRIPTION
Doc/comment only — no runtime change. Pins the real per-environment bot mapping so the drift stops recurring:

- local → `kitobzorim_bot` (code default + `.env.example`)
- dev → `octagonuzbot` (kitobzor-dev server `.env`)
- prod → `kitobzor_uz_bot` (kitobzor-prod server `.env`)

Fixes `.env.production.example` (dev-server template) which wrongly said `kitobzorim_bot`, and clarifies the `env.js` + `.env.example` comments. Each server `.env` already carries the correct value, so no container rebuild is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)