### PR TITLE
fix: show wanted books on the home page

### DIFF
--- a/src/app/[locale]/page.jsx
+++ b/src/app/[locale]/page.jsx
@@ -81,18 +81,23 @@ const page = async ({ params }) => {
   // each home component fetched its own data after hydration — six
   // round-trips stacked behind React mount, ~600-1200 ms of empty
   // skeleton on cold loads. Now the page lands fully populated.
-  const [storiesRes, shopsRes, sellRes, giftRes, exchangeRes, rentRes] = await Promise.all([
-    serverGet("/api/v1/stories/", { locale, revalidate: 120 }),
-    serverGet("/api/v1/shop/list/", {
-      locale,
-      params: { is_active: true, limit: 10 },
-      revalidate: 600,
-    }),
-    serverGet("/api/v1/book/list/", { locale, params: bookParams("sell") }),
-    serverGet("/api/v1/book/list/", { locale, params: bookParams("gift") }),
-    serverGet("/api/v1/book/list/", { locale, params: bookParams("exchange") }),
-    serverGet("/api/v1/book/list/", { locale, params: bookParams("rent") }),
-  ]);
+  const [storiesRes, shopsRes, sellRes, giftRes, exchangeRes, rentRes, wantedRes] =
+    await Promise.all([
+      serverGet("/api/v1/stories/", { locale, revalidate: 120 }),
+      serverGet("/api/v1/shop/list/", {
+        locale,
+        params: { is_active: true, limit: 10 },
+        revalidate: 600,
+      }),
+      serverGet("/api/v1/book/list/", { locale, params: bookParams("sell") }),
+      serverGet("/api/v1/book/list/", { locale, params: bookParams("gift") }),
+      serverGet("/api/v1/book/list/", { locale, params: bookParams("exchange") }),
+      serverGet("/api/v1/book/list/", { locale, params: bookParams("rent") }),
+      // Demand, not supply. The API hides `wanted` from every unscoped feed, so
+      // this needs its own explicit request — it can never ride along in one of
+      // the sections above.
+      serverGet("/api/v1/book/list/", { locale, params: bookParams("wanted") }),
+    ]);
 
   const initialStories = unwrapList(storiesRes).items;
   const initialShops = unwrapList(shopsRes).items;
@@ -100,6 +105,7 @@ const page = async ({ params }) => {
   const initialGift = unwrapList(giftRes).items;
   const initialExchange = unwrapList(exchangeRes).items;
   const initialRent = unwrapList(rentRes).items;
+  const initialWanted = unwrapList(wantedRes).items;
 
   return (
     <>
@@ -137,6 +143,16 @@ const page = async ({ params }) => {
         titleKey="eldagiRentTitle"
         viewAllHref="/community/rent"
         initialBooks={initialRent}
+      />
+      {/* Demand section — last, mirroring the /community tab order. Reads as a
+          call to action for anyone who HAS one of these books. Self-hides while
+          there are no wanted posts (HomeBookList returns null on an empty list). */}
+      <HomeBookList
+        type="wanted"
+        ownerType="user"
+        titleKey="eldagiWantedTitle"
+        viewAllHref="/community/wanted"
+        initialBooks={initialWanted}
       />
 
       <FooterOne />

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -916,7 +916,8 @@
     "eldagiSellTitle": "Community books for sale",
     "eldagiGiftTitle": "Community gift books",
     "eldagiExchangeTitle": "Community exchange",
-    "eldagiRentTitle": "Community rentals"
+    "eldagiRentTitle": "Community rentals",
+    "eldagiWantedTitle": "Books people are looking for"
   },
   "HomeMainEntryChips": {
     "shops": "From shops",

--- a/src/messages/kaa.json
+++ b/src/messages/kaa.json
@@ -916,7 +916,8 @@
     "eldagiSellTitle": "Eldegi satılatuǵın kitaplar",
     "eldagiGiftTitle": "Eldegi sıylıq kitaplar",
     "eldagiExchangeTitle": "El menen almasıw",
-    "eldagiRentTitle": "Elden ijaraǵa"
+    "eldagiRentTitle": "Elden ijaraǵa",
+    "eldagiWantedTitle": "Eldegi izlenip atırǵan kitaplar"
   },
   "HomeMainEntryChips": {
     "shops": "Dúkenlerdegi",

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -916,7 +916,8 @@
     "eldagiSellTitle": "Книги от пользователей на продажу",
     "eldagiGiftTitle": "Книги-подарки от пользователей",
     "eldagiExchangeTitle": "Обмен от пользователей",
-    "eldagiRentTitle": "Аренда от пользователей"
+    "eldagiRentTitle": "Аренда от пользователей",
+    "eldagiWantedTitle": "Книги, которые ищут"
   },
   "HomeMainEntryChips": {
     "shops": "От магазинов",

--- a/src/messages/uz.json
+++ b/src/messages/uz.json
@@ -916,7 +916,8 @@
     "eldagiSellTitle": "Eldagi sotiladigan kitoblar",
     "eldagiGiftTitle": "Eldagi sovg'a kitoblar",
     "eldagiExchangeTitle": "El bilan almashish",
-    "eldagiRentTitle": "Eldan ijaraga"
+    "eldagiRentTitle": "Eldan ijaraga",
+    "eldagiWantedTitle": "Eldan qidirilayotgan kitoblar"
   },
   "HomeMainEntryChips": {
     "shops": "Do'konlardagi",

--- a/tests/unit/communityTabs.test.js
+++ b/tests/unit/communityTabs.test.js
@@ -70,6 +70,40 @@ describe("community tab slugs", () => {
     });
   });
 
+  it("every tab has its own home-page section", () => {
+    // The home feed renders one <HomeBookList type="..."> per book type. A new
+    // type that gets a /community tab but no home section is invisible on the
+    // landing page — which is exactly what happened when `wanted` shipped.
+    const source = readSource("src/app/[locale]/page.jsx");
+    const rendered = [...source.matchAll(/<HomeBookList\s+type="([^"]+)"/g)].map((m) => m[1]);
+    TAB_SLUGS.filter((slug) => slug !== "all").forEach((slug) => {
+      expect(rendered, `home page missing a HomeBookList for "${slug}"`).toContain(slug);
+    });
+  });
+
+  it("every home section prefetches its books server-side", () => {
+    // Each section is server-rendered from a `bookParams(<type>)` request. A
+    // section without one falls back to a client fetch — a visible skeleton
+    // flash on the landing page.
+    const source = readSource("src/app/[locale]/page.jsx");
+    const prefetched = [...source.matchAll(/bookParams\("([^"]+)"\)/g)].map((m) => m[1]);
+    TAB_SLUGS.filter((slug) => slug !== "all").forEach((slug) => {
+      expect(prefetched, `home page missing bookParams("${slug}")`).toContain(slug);
+    });
+  });
+
+  it("every home section title exists in all locales", () => {
+    const source = readSource("src/app/[locale]/page.jsx");
+    const titleKeys = [...source.matchAll(/titleKey="([^"]+)"/g)].map((m) => m[1]);
+    expect(titleKeys.length).toBeGreaterThan(0);
+    LOCALES.forEach((locale) => {
+      const messages = readMessages(locale);
+      titleKeys.forEach((key) => {
+        expect(messages.HomeBookList?.[key], `${locale}: HomeBookList.${key}`).toBeTruthy();
+      });
+    });
+  });
+
   it("every book-type badge maps to an existing chip label", () => {
     const messages = readMessages("uz");
     Object.keys(BOOK_TYPE_VISUALS).forEach((apiType) => {


### PR DESCRIPTION
## Muammo

Home sahifada har bir kitob turi uchun alohida bo'lim bor (sotiladigan / sovg'a / almashish / ijaraga), lekin `wanted` uchun bo'lim qo'shilmagan edi. Natijada «Kerak» e'lonlari faqat `/community/wanted` orqali topilardi va bosh sahifada umuman ko'rinmasdi.

Reliz (#105) dan keyin darhol xabar qilindi. Prodda 3 ta wanted e'lon bor, API'da to'g'ri qaytadi — muammo faqat home sahifada.

## Yechim

Bo'lim qo'shildi — oxirida, `/community` tab tartibini takrorlab.

Prefetch **alohida so'rov** bo'lishi shart: API `wanted`ni har qanday scope'siz feed'dan yashiradi, shuning uchun u to'rtta taklif bo'limining birortasiga qo'shilib kela olmaydi. Qolganlari kabi bo'lim bo'sh bo'lsa o'zini yashiradi.

## Regressiya himoyasi

Uchta yangi test — har bir «all» bo'lmagan tab slug'i uchun:

1. `HomeBookList` bo'limi mavjudligi
2. `bookParams()` orqali server-side prefetch qilinishi (aks holda skeleton chaqnashi)
3. `titleKey` to'rtala tilda mavjudligi

Birinchisi chiqarilgan kodda **tushgan bo'lardi**.

## Holat

- 191 test yashil / 27 fayl
- `i18n:check` yashil — 940 kalit, uz/ru/en/kaa sinxron
- `npm run build` yashil

Backend o'zgarishi kerak emas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
