### PR TITLE
fix: home shops row shows 6, not 10

### DIFF
--- a/src/app/[locale]/page.jsx
+++ b/src/app/[locale]/page.jsx
@@ -86,7 +86,12 @@ const page = async ({ params }) => {
       serverGet("/api/v1/stories/", { locale, revalidate: 120 }),
       serverGet("/api/v1/shop/list/", {
         locale,
-        params: { is_active: true, limit: 10 },
+        // 6 for the same reason as the book rows: HomeShopsRow is a 3-column
+        // grid on desktop, so 6 fills exactly two rows with no dangling card.
+        // It also matches what the component itself assumes — its skeleton
+        // count and its client-side fallback fetch are both 6; this server
+        // prefetch was the odd one out at 10 and silently won.
+        params: { is_active: true, limit: 6 },
         revalidate: 600,
       }),
       serverGet("/api/v1/book/list/", { locale, params: bookParams("sell") }),

--- a/src/services/shops.js
+++ b/src/services/shops.js
@@ -19,7 +19,10 @@ export async function getShopById(id) {
   return { shop: normalizeItem(data), raw: data };
 }
 
-export async function getHomePageShops(limit = 8) {
+// 6 = two full rows of the home row's 3-column desktop grid. Was 8, which no
+// caller used (HomeShopsRow always passes 6 explicitly) but made the intended
+// size ambiguous — three different numbers described one row.
+export async function getHomePageShops(limit = 6) {
   return await getShops({ is_active: true, limit });
 }
 


### PR DESCRIPTION
## Muammo

Home sahifadagi do'konlar qatori 10 ta do'kon ko'rsatardi. Desktop'da grid 3 ustunli — 10 ta karta 3 qator + osilib qolgan bitta karta bo'lib chiqardi.

`HomeShopsRow` aslida **6 taga mo'ljallangan**: skeleton soni 6, client-side fallback `getHomePageShops(6)`. Lekin `page.jsx` dagi server prefetch `limit: 10` uzatardi va server-rendering asosiy yo'l bo'lgani uchun aynan o'sha g'olib chiqardi.

## Yechim

Prefetch 6 ga tushirildi — komponentning o'z taxminiga va yuqoridagi kitob qatorlariga mos (ular ham aynan shu sabab 6 ishlatadi: 3 ustunli gridda ikkita to'liq qator).

Bonus: `getHomePageShops` default'i 8 → 6. Uni hech kim ishlatmasdi (yagona chaqiruvchi 6 ni aniq uzatadi), lekin bitta qatorni uchta har xil raqam tavsiflab turardi.

## Holat

- 191 test yashil, lint toza, `npm run build` yashil
- Backend o'zgarishi kerak emas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
