### PR TITLE
Release: home shops row limit 6

### DIFF
--- a/src/app/[locale]/page.jsx
+++ b/src/app/[locale]/page.jsx
@@ -86,7 +86,12 @@ const page = async ({ params }) => {
       serverGet("/api/v1/stories/", { locale, revalidate: 120 }),
       serverGet("/api/v1/shop/list/", {
         locale,
-        params: { is_active: true, limit: 10 },
+        // 6 for the same reason as the book rows: HomeShopsRow is a 3-column
+        // grid on desktop, so 6 fills exactly two rows with no dangling card.
+        // It also matches what the component itself assumes — its skeleton
+        // count and its client-side fallback fetch are both 6; this server
+        // prefetch was the odd one out at 10 and silently won.
+        params: { is_active: true, limit: 6 },
         revalidate: 600,
       }),
       serverGet("/api/v1/book/list/", { locale, params: bookParams("sell") }),

--- a/src/services/shops.js
+++ b/src/services/shops.js
@@ -19,7 +19,10 @@ export async function getShopById(id) {
   return { shop: normalizeItem(data), raw: data };
 }
 
-export async function getHomePageShops(limit = 8) {
+// 6 = two full rows of the home row's 3-column desktop grid. Was 8, which no
+// caller used (HomeShopsRow always passes 6 explicitly) but made the intended
+// size ambiguous — three different numbers described one row.
+export async function getHomePageShops(limit = 6) {
   return await getShops({ is_active: true, limit });
 }
 


### PR DESCRIPTION
Release: `dev` → `main`.

Home sahifadagi do'konlar qatori 10 ta o'rniga 6 ta ko'rsatadi (PR #108).

`HomeShopsRow` aslida 6 taga mo'ljallangan (skeleton 6, client fallback 6), lekin `page.jsx` dagi server prefetch `limit: 10` uzatib, uni bosib ketardi. Desktopda 3 ustunli gridda 10 ta karta 3 qator + osilib qolgan bitta karta bo'lib chiqardi.

Bonus: `getHomePageShops` defaulti 8 → 6 (hech kim ishlatmasdi, lekin bitta qatorni uchta raqam tavsiflardi).

**Devda tekshirilgan** — devda faqat 5 ta aktiv do'kon bor, shuning uchun haqiqiy 6-limit sinovi prodda ko'rinadi (12 ta do'kon).

CI yashil, 191 test, backend o'zgarishi kerak emas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)